### PR TITLE
fix: row ink gates on callbacks, not colors (2.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.14.0
+
+*   **FIX**: Row splash / hover / highlight now use the colors you set on `TablePlusBodyTheme`, in every mode
+    *   The row's ink colors were passed as `null` whenever the row was not tap-selectable — notably in editing mode — to suppress the ink. But `null` does not suppress it: `InkWell` resolves `widget.splashColor ?? Theme.of(context).splashColor`, so the table silently rendered Flutter's faint grey default instead of your theme. On a white row that default is nearly invisible, which made "no splash" and "a splash you cannot see" look identical. `TablePlusBodyTheme.splashColor` already documented the real contract: *pass `Colors.transparent` to disable*
+    *   Which ink appears is now decided by which callbacks are wired, which is what `InkWell` actually gates on — a splash/highlight needs a primary-button callback, a hover highlight needs any callback. The row shell previously forwarded `onDoubleTap` / `onSecondaryTapDown` as non-null closures that merely called a possibly-null handler, so `InkWell` always looked enabled and painted a splash for a tap that did nothing. Those closures are now forwarded only when a handler exists, and the theme's colors are always passed through
+*   **BEHAVIOR**: Tapping a row now selects it while `isEditable` is true
+    *   Tapping an **editable** column still starts editing that cell — the cell's own `GestureDetector` wins the gesture arena against the row-level tap. Tapping anywhere else on a selectable row now toggles its selection, as it does outside editing mode
+    *   Row-tap selection was suppressed during editing since editing was introduced, when the two modes were mutually exclusive (`assert((isSelectable && isEditable) == false)`). That assert was removed to let them coexist, but the row guard survived, leaving a contradiction: while editing you could still select a row via its checkbox, just not by clicking it
+    *   If you relied on rows not selecting on tap while editing, handle it in your `onRowSelectionChanged`
+
 ## 2.13.1
 
 *   **PERF**: Rows no longer rebuild on pointer hover when there are no hover buttons

--- a/example/lib/pages/playground/playground_page.dart
+++ b/example/lib/pages/playground/playground_page.dart
@@ -1030,6 +1030,9 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
         showHorizontalDividers: _settings.showDividers,
         showVerticalDividers: _settings.showDividers,
         selectedRowColor: Colors.blue.shade100.withValues(alpha: 0.6),
+        splashColor: _settings.splashColor.color,
+        hoverColor: _settings.hoverColor.color,
+        highlightColor: _settings.highlightColor.color,
         rowHeight: _settings.rowHeight,
       ),
       editableTheme: TablePlusEditableTheme(

--- a/example/lib/pages/playground/widgets/settings_panel.dart
+++ b/example/lib/pages/playground/widgets/settings_panel.dart
@@ -3,6 +3,27 @@ import 'package:flutter/material.dart';
 import 'package:flutter_table_plus/flutter_table_plus.dart';
 import 'performance_monitor.dart';
 
+/// A pickable value for the body theme's ink colors (splash / hover /
+/// highlight).
+///
+/// [themeDefault] passes `null` through, which is what makes the table fall
+/// back to the framework's own ink colors — on a white row those are faint
+/// enough to look like nothing is happening at all, so the loud presets exist
+/// to tell "no ink" apart from "ink you cannot see".
+enum InkColorOption {
+  themeDefault('Theme default', null),
+  none('None (transparent)', Colors.transparent),
+  red('Red', Color(0x80F44336)),
+  blue('Blue', Color(0x803F51B5)),
+  green('Green', Color(0x804CAF50)),
+  black('Black', Color(0x40000000));
+
+  const InkColorOption(this.label, this.color);
+
+  final String label;
+  final Color? color;
+}
+
 /// Playground settings configuration
 class PlaygroundSettings {
   // Data settings
@@ -27,6 +48,9 @@ class PlaygroundSettings {
   final double resizeHandleWidth;
   final bool showAlternateRows;
   final bool showDividers;
+  final InkColorOption splashColor;
+  final InkColorOption hoverColor;
+  final InkColorOption highlightColor;
   final bool dynamicRowHeight;
   final bool dimInactiveRows;
   final bool showCheckboxColumn;
@@ -90,6 +114,9 @@ class PlaygroundSettings {
     this.resizeHandleWidth = 8.0,
     this.showAlternateRows = true,
     this.showDividers = true,
+    this.splashColor = InkColorOption.themeDefault,
+    this.hoverColor = InkColorOption.themeDefault,
+    this.highlightColor = InkColorOption.themeDefault,
     this.dynamicRowHeight = false,
     this.dimInactiveRows = false,
     this.showCheckboxColumn = true,
@@ -144,6 +171,9 @@ class PlaygroundSettings {
     double? resizeHandleWidth,
     bool? showAlternateRows,
     bool? showDividers,
+    InkColorOption? splashColor,
+    InkColorOption? hoverColor,
+    InkColorOption? highlightColor,
     bool? dynamicRowHeight,
     bool? dimInactiveRows,
     bool? showCheckboxColumn,
@@ -197,6 +227,9 @@ class PlaygroundSettings {
       resizeHandleWidth: resizeHandleWidth ?? this.resizeHandleWidth,
       showAlternateRows: showAlternateRows ?? this.showAlternateRows,
       showDividers: showDividers ?? this.showDividers,
+      splashColor: splashColor ?? this.splashColor,
+      hoverColor: hoverColor ?? this.hoverColor,
+      highlightColor: highlightColor ?? this.highlightColor,
       dynamicRowHeight: dynamicRowHeight ?? this.dynamicRowHeight,
       dimInactiveRows: dimInactiveRows ?? this.dimInactiveRows,
       showCheckboxColumn: showCheckboxColumn ?? this.showCheckboxColumn,
@@ -893,6 +926,46 @@ class SettingsPanel extends StatelessWidget {
           onChanged: (value) {
             onSettingsChanged(settings.copyWith(showAlternateRows: value));
           },
+        ),
+
+        _buildDropdownRow<InkColorOption>(
+          label: 'Splash Color',
+          value: settings.splashColor,
+          items: InkColorOption.values,
+          itemLabel: (option) => option.label,
+          onChanged: (option) {
+            onSettingsChanged(settings.copyWith(splashColor: option));
+          },
+        ),
+
+        _buildDropdownRow<InkColorOption>(
+          label: 'Hover Color',
+          value: settings.hoverColor,
+          items: InkColorOption.values,
+          itemLabel: (option) => option.label,
+          onChanged: (option) {
+            onSettingsChanged(settings.copyWith(hoverColor: option));
+          },
+        ),
+
+        _buildDropdownRow<InkColorOption>(
+          label: 'Highlight Color',
+          value: settings.highlightColor,
+          items: InkColorOption.values,
+          itemLabel: (option) => option.label,
+          onChanged: (option) {
+            onSettingsChanged(settings.copyWith(highlightColor: option));
+          },
+        ),
+
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: 4),
+          child: Text(
+            'Row splash needs Selection on and Editing off — while editing, the '
+            'ink layer stays for row gestures but the selection splash is '
+            'suppressed.',
+            style: TextStyle(fontSize: 11, color: Colors.black54),
+          ),
         ),
 
         _buildSwitchTile(

--- a/lib/src/widgets/flutter_table_plus.dart
+++ b/lib/src/widgets/flutter_table_plus.dart
@@ -146,6 +146,10 @@ class FlutterTablePlus<T> extends StatefulWidget {
   final void Function(String columnKey, SortDirection direction)? onSort;
 
   /// Whether the table supports cell editing.
+  ///
+  /// Editing coexists with selection: tapping an editable column starts editing
+  /// that cell, while tapping anywhere else on a selectable row still selects
+  /// the row, exactly as it does outside editing mode.
   final bool isEditable;
 
   /// Callback when a cell value is changed.

--- a/lib/src/widgets/table_plus_row_widget.dart
+++ b/lib/src/widgets/table_plus_row_widget.dart
@@ -79,20 +79,22 @@ abstract class TablePlusRowWidget<T> extends StatefulWidget {
       bool isSelected)? get onRowSecondaryTapDown;
 
   /// Shared row-tap selection gating for every row type. A tap selects only
-  /// when selection is enabled, the table is not editing, and the row has an
-  /// id — otherwise it is a no-op.
+  /// when selection is enabled and the row has an id — otherwise it is a no-op.
+  ///
+  /// Editing does not suppress this. An editable *cell* wraps itself in its own
+  /// [GestureDetector], which wins the gesture arena against this row-level tap,
+  /// so tapping an editable column still starts editing rather than selecting.
   void handleSelectionTap() {
-    if (isEditable || !isSelectable) return;
+    if (!isSelectable) return;
     final id = selectionId;
     if (id == null) return;
     onRowSelectionChanged(id);
   }
 
   /// Whether the row wraps its content in a selection ink well. True only when
-  /// selection is enabled, the table is not editing, and the row has an id.
+  /// selection is enabled and the row has an id.
   /// This same predicate drives the transparent-selection decoration.
-  bool get enableSelectionInk =>
-      isSelectable && !isEditable && selectionId != null;
+  bool get enableSelectionInk => isSelectable && selectionId != null;
 }
 
 /// Shared base [State] holding the row build skeleton (the template method).
@@ -149,22 +151,28 @@ abstract class TablePlusRowStateBase<W extends TablePlusRowWidget<T>, T>
       enableInteractionLayer: tapSelect || wantsRowGesture,
       inkKey: ValueKey(id),
       onTap: tapSelect ? widget.handleSelectionTap : null,
-      onDoubleTap: () => widget.onRowDoubleTap?.call(id!),
-      onSecondaryTapDown: (details, renderBox) => widget.onRowSecondaryTapDown
-          ?.call(id!, details, renderBox, widget.isSelected),
+      // Forward a callback only when one actually exists. A non-null closure
+      // that merely calls a null handler still reads as "enabled" to InkWell,
+      // which is what makes it paint a splash for a tap that does nothing.
+      onDoubleTap: (id != null && widget.onRowDoubleTap != null)
+          ? () => widget.onRowDoubleTap!(id)
+          : null,
+      onSecondaryTapDown: (id != null && widget.onRowSecondaryTapDown != null)
+          ? (details, renderBox) => widget.onRowSecondaryTapDown!(
+              id, details, renderBox, widget.isSelected)
+          : null,
       doubleClickTime: theme.doubleClickTime,
       backgroundColor: widget.backgroundColor,
-      // Selection ink colors only when tap-selecting; edit-mode row gestures
-      // shouldn't paint a selection splash.
-      hoverColor: tapSelect
-          ? theme.getEffectiveHoverColor(widget.isSelected, widget.isDim)
-          : null,
-      splashColor: tapSelect
-          ? theme.getEffectiveSplashColor(widget.isSelected, widget.isDim)
-          : null,
-      highlightColor: tapSelect
-          ? theme.getEffectiveHighlightColor(widget.isSelected, widget.isDim)
-          : null,
+      // Which ink appears is decided by which callbacks exist, not by the
+      // colors: InkWell paints a splash/highlight only when a primary-button
+      // callback is wired, and a hover highlight only when any callback is.
+      // Passing `null` here would not suppress ink — it selects the framework's
+      // default color (see TablePlusBodyTheme.splashColor).
+      hoverColor: theme.getEffectiveHoverColor(widget.isSelected, widget.isDim),
+      splashColor:
+          theme.getEffectiveSplashColor(widget.isSelected, widget.isDim),
+      highlightColor:
+          theme.getEffectiveHighlightColor(widget.isSelected, widget.isDim),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_table_plus
 description: "A highly customizable and efficient table widget for Flutter, featuring synchronized scrolling, theming, sorting, selection, column reordering, hover buttons, and expandable rows."
-version: 2.13.1
+version: 2.14.0
 homepage: https://github.com/kihyun1998/flutter_table_plus
 repository: https://github.com/kihyun1998/flutter_table_plus
 topics:

--- a/test/edit_mode_row_ink_test.dart
+++ b/test/edit_mode_row_ink_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_table_plus/flutter_table_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Row ink is gated by which callbacks are wired, not by the colors passed in.
+//
+// Passing `splashColor: null` does NOT suppress a splash — InkWell resolves
+// `widget.splashColor ?? Theme.of(context).splashColor`, so it silently swaps
+// the caller's theme for the framework default. These tests pin the callback
+// gate and the colour passthrough, and the selection-while-editing behavior
+// that fixing the gate unlocked.
+
+Map<String, TablePlusColumn<Map<String, dynamic>>> _columns() {
+  final b = TableColumnsBuilder<Map<String, dynamic>>();
+  b.addColumn(
+    'name',
+    TablePlusColumn<Map<String, dynamic>>(
+      key: 'name',
+      label: 'Name',
+      order: 0,
+      valueAccessor: (r) => r['name'],
+      width: 160,
+      editable: true,
+    ),
+  );
+  b.addColumn(
+    'tag',
+    TablePlusColumn<Map<String, dynamic>>(
+      key: 'tag',
+      label: 'Tag',
+      order: 0,
+      valueAccessor: (r) => r['tag'],
+      width: 160,
+    ),
+  );
+  return b.build();
+}
+
+const _data = [
+  {'id': '1', 'name': 'Alpha', 'tag': 'T1'},
+  {'id': '2', 'name': 'Bravo', 'tag': 'T2'},
+];
+
+Future<void> _pump(
+  WidgetTester tester, {
+  bool isSelectable = true,
+  bool isEditable = true,
+  TablePlusTheme theme = const TablePlusTheme(),
+  void Function(String id, bool isSelected)? onRowSelectionChanged,
+  void Function(String id, TapDownDetails d, RenderBox box, bool sel)?
+      onRowSecondaryTapDown,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: FlutterTablePlus<Map<String, dynamic>>(
+          columns: _columns(),
+          data: _data,
+          rowId: (r) => r['id'] as String,
+          isSelectable: isSelectable,
+          isEditable: isEditable,
+          theme: theme,
+          onCellChanged: (_, __, ___, ____, _____) {},
+          onRowSelectionChanged: onRowSelectionChanged,
+          onRowSecondaryTapDown: onRowSecondaryTapDown,
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// The row's own InkWell — not the checkbox's.
+Finder _rowInkWell() => find
+    .descendant(of: find.byType(CustomInkWell), matching: find.byType(InkWell))
+    .first;
+
+void main() {
+  testWidgets('tapping a non-editable cell selects the row while editing',
+      (tester) async {
+    final selected = <String>[];
+    await _pump(tester, onRowSelectionChanged: (id, _) => selected.add(id));
+
+    await tester.tap(find.text('T2'));
+    await tester.pumpAndSettle();
+
+    expect(selected, ['2']);
+  });
+
+  testWidgets('tapping an editable cell edits it and does not select the row',
+      (tester) async {
+    final selected = <String>[];
+    await _pump(tester, onRowSelectionChanged: (id, _) => selected.add(id));
+
+    await tester.tap(find.text('Alpha'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(EditableText), findsOneWidget);
+    expect(selected, isEmpty);
+  });
+
+  testWidgets('a row with only a secondary-tap handler wires no primary tap',
+      (tester) async {
+    // No selection and no double-tap handler: the ink layer exists only for the
+    // right-click gesture, so InkWell must not look tappable — otherwise it
+    // paints a splash for a left click that does nothing.
+    await _pump(
+      tester,
+      isSelectable: false,
+      onRowSecondaryTapDown: (_, __, ___, ____) {},
+    );
+
+    expect(tester.widget<InkWell>(_rowInkWell()).onTap, isNull);
+  });
+
+  testWidgets('the body theme ink colors reach the row InkWell while editing',
+      (tester) async {
+    const splash = Color(0x80FF0000);
+    const hover = Color(0x8000FF00);
+    const highlight = Color(0x800000FF);
+
+    await _pump(
+      tester,
+      theme: const TablePlusTheme(
+        bodyTheme: TablePlusBodyTheme(
+          splashColor: splash,
+          hoverColor: hover,
+          highlightColor: highlight,
+        ),
+      ),
+    );
+
+    final ink = tester.widget<InkWell>(_rowInkWell());
+    expect(ink.splashColor, splash);
+    expect(ink.hoverColor, hover);
+    expect(ink.highlightColor, highlight);
+  });
+}

--- a/test/row_selection_tap_test.dart
+++ b/test/row_selection_tap_test.dart
@@ -65,7 +65,7 @@ class _TestRowState extends State<_TestRow> {
 
 void main() {
   group('TablePlusRowWidget.handleSelectionTap', () {
-    test('toggles selection when selectable, not editable, and id present', () {
+    test('toggles selection when selectable and id present', () {
       final calls = <String>[];
       _TestRow(
         isEditable: false,
@@ -76,7 +76,7 @@ void main() {
       expect(calls, ['r1']);
     });
 
-    test('does nothing in editable mode', () {
+    test('still toggles selection in editable mode', () {
       final calls = <String>[];
       _TestRow(
         isEditable: true,
@@ -84,7 +84,7 @@ void main() {
         selectionId: 'r1',
         onRowSelectionChanged: calls.add,
       ).handleSelectionTap();
-      expect(calls, isEmpty);
+      expect(calls, ['r1']);
     });
 
     test('does nothing when not selectable', () {
@@ -124,7 +124,7 @@ void main() {
       );
     }
 
-    test('true only when selectable, not editing, and id present', () {
+    test('true only when selectable and id present', () {
       expect(
         row(isEditable: false, isSelectable: true, selectionId: 'r')
             .enableSelectionInk,
@@ -132,11 +132,11 @@ void main() {
       );
     });
 
-    test('false while editing', () {
+    test('still true while editing', () {
       expect(
         row(isEditable: true, isSelectable: true, selectionId: 'r')
             .enableSelectionInk,
-        isFalse,
+        isTrue,
       );
     });
 


### PR DESCRIPTION
Closes #39.

## What was wrong

The row's selection ink was suppressed by passing `null`:

```dart
splashColor: tapSelect ? theme.getEffectiveSplashColor(...) : null,
```

`null` is not "off". `InkWell` resolves `widget.splashColor ?? Theme.of(context).splashColor`, so the table silently swapped the caller's theme for Flutter's faint grey default — invisible on a white row, faintly visible on a tinted `alternateRowColor` row. `TablePlusBodyTheme.splashColor` already documents the real contract: *pass `Colors.transparent` to disable*.

The colors were never the gate. `InkWell` gates on **callbacks**: splash/highlight need a primary-button callback, hover needs any callback. And the row shell forwarded `onDoubleTap` / `onSecondaryTapDown` as non-null closures that merely called a possibly-null handler — so `InkWell` always looked enabled and painted a splash for a tap that did nothing.

## What changed

- Forward those closures only when a handler exists.
- Drop the color ternaries; always pass the theme's colors. With the callbacks fixed, ink cannot appear where it shouldn't.
- Stop suppressing row-tap selection while editing.

## Behavior change

Tapping a row now selects it while `isEditable` is true. Tapping an **editable** column still starts editing — the cell's `GestureDetector` wins the gesture arena.

The old guard dated from when the two modes could not coexist (`assert((isSelectable && isEditable) == false)`). That assert was removed in `6bfbaa7` to let them coexist; the guard survived, leaving a contradiction — while editing you could select a row via its checkbox, just not by clicking it. Nothing documented the restriction; the doc note that once described it is long gone.

Minor bump, called out in CHANGELOG. No opt-out flag: the old behavior was self-contradictory, and a flag would re-tangle `enableInteractionLayer`.

## Tests

Four new cases plus two inverted ones. `row_selection_tap_test.dart`'s `does nothing in editable mode` / `false while editing` are inverted rather than deleted — they pinned behavior that outlived its premise, and pinning the new contract keeps the next reader from "restoring" the old one.

`flutter analyze` clean, `flutter test` green (340).

## Playground

The first commit adds ink-color controls to the example. They exist because this bug was invisible without them: "no splash" and "a splash you cannot see" looked identical. They found it.

## See also

- #38 — closed `wontfix`; hoisting all per-row `Material`s to the root regressed scroll (p50 2.6 ms → 25 ms)
- #40 — the part of #38 that survives: two nested `Material`s inside the selection cell are redundant once this PR lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
