### PR TITLE
perf: drop the two nested Materials inside the selection cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
     *   Tapping an **editable** column still starts editing that cell — the cell's own `GestureDetector` wins the gesture arena against the row-level tap. Tapping anywhere else on a selectable row now toggles its selection, as it does outside editing mode
     *   Row-tap selection was suppressed during editing since editing was introduced, when the two modes were mutually exclusive (`assert((isSelectable && isEditable) == false)`). That assert was removed to let them coexist, but the row guard survived, leaving a contradiction: while editing you could still select a row via its checkbox, just not by clicking it
     *   If you relied on rows not selecting on tap while editing, handle it in your `onRowSelectionChanged`
+*   **PERF**: The selection cell no longer allocates its own `Material`s — up to three per row become one
+    *   `TablePlusSelectionCell` wrapped its checkbox in a transparent `Material`, and its cell-tap `InkWell` in another, so that `FlutterCheckbox`'s internal `InkWell` would find a `Material` ancestor and the table would render without a `Scaffold` (#3). But `CustomInkWell` already wraps the whole row in one, and the selection cell only renders when the row is selectable — which is exactly when that row `Material` exists. Both were redundant
+    *   A `Material` is not cheap: with the default `canvas` type it expands to `AnimatedDefaultTextStyle` → `AnimatedPhysicalModel` → `PhysicalModel` → `_InkFeatures`, i.e. two render objects and two implicit-animation controllers. Removing them takes a selection-enabled row from three to one
+    *   Ink is still painted per row, so this is unrelated to the root-`Material` hoist rejected in #38 — that regressed scroll because it moved ink painting outside each row's `RepaintBoundary`
+*   **TEST**: The #3 regression guard now exercises the checkbox, not just its rendering
+    *   `InkWell` resolves `Material.of` only when it paints ink — on tap (`_createSplash`) and on hover/press (`updateHighlight`) — so a checkbox with no `Material` ancestor builds fine and throws only when touched. The old guard pumped the table and asserted no exception, which passed for an incidental reason: the row's `Ink` demands a `Material` at build. The guard now taps the checkbox, taps the cell (`cellTapTogglesCheckbox`, previously untested), and hovers the checkbox
 
 ## 2.13.1
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A highly customizable, type-safe Flutter table widget with synchronized scrollin
 
 ```yaml
 dependencies:
-  flutter_table_plus: ^2.13.1
+  flutter_table_plus: ^2.14.0
 ```
 
 ```bash

--- a/lib/src/widgets/cells/table_plus_selection_cell.dart
+++ b/lib/src/widgets/cells/table_plus_selection_cell.dart
@@ -31,29 +31,25 @@ class TablePlusSelectionCell extends StatelessWidget {
       // centered, so padding never changed its position, only shrank the room
       // it had; a narrow selection column would then clip it away entirely (#4).
       //
-      // The transparent Material gives FlutterCheckbox's internal InkWell an
-      // ancestor so the table works without a Scaffold/Material (e.g. on
-      // desktop) (#3).
+      // Neither the checkbox's internal InkWell nor the cell-tap InkWell below
+      // owns a Material. They paint onto the row's — CustomInkWell wraps the
+      // whole row whenever the row is selectable, and this cell only renders
+      // when it is. That row Material is what keeps the table working without a
+      // Scaffold/Material of its own (#3).
       content = Center(
-        child: Material(
-          type: MaterialType.transparency,
-          child: checkboxTheme.buildCheckbox(
-            value: isSelected,
-            onChanged:
-                rowId != null ? (value) => onSelectionChanged(rowId!) : null,
-          ),
+        child: checkboxTheme.buildCheckbox(
+          value: isSelected,
+          onChanged:
+              rowId != null ? (value) => onSelectionChanged(rowId!) : null,
         ),
       );
 
       if (checkboxTheme.cellTapTogglesCheckbox) {
-        content = Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: rowId != null ? () => onSelectionChanged(rowId!) : null,
-            mouseCursor:
-                rowId != null ? SystemMouseCursors.click : MouseCursor.defer,
-            child: content,
-          ),
+        content = InkWell(
+          onTap: rowId != null ? () => onSelectionChanged(rowId!) : null,
+          mouseCursor:
+              rowId != null ? SystemMouseCursors.click : MouseCursor.defer,
+          child: content,
         );
       }
     } else {

--- a/test/checkbox_material_ancestor_test.dart
+++ b/test/checkbox_material_ancestor_test.dart
@@ -1,14 +1,24 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_table_plus/flutter_table_plus.dart';
+import 'package:flutter_table_plus/src/widgets/cells/table_plus_selection_cell.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-// Regression for #3: the table's checkboxes must render without a Material
-// ancestor (e.g. a desktop app that doesn't use Material / Scaffold).
+// Regression for #3: the table's checkboxes must render AND respond without a
+// Material ancestor (e.g. a desktop app that doesn't use Material / Scaffold).
 //
 // MaterialApp WITHOUT a Scaffold provides Directionality / MediaQuery /
 // DefaultTextStyle but NOT a Material widget — exactly the reporter's setup.
+//
+// Rendering alone is a weak guarantee: InkWell only looks up `Material.of` when
+// it paints ink — on tap (`_createSplash`) and on hover/focus/press
+// (`updateHighlight`). A checkbox with no Material ancestor therefore builds
+// fine and only throws when someone touches it. These tests touch it.
 
-Widget _table() {
+Widget _table({
+  void Function(String rowId, bool isSelected)? onRowSelectionChanged,
+  bool cellTapTogglesCheckbox = false,
+}) {
   return FlutterTablePlus<Map<String, dynamic>>(
     columns: {
       'name': TablePlusColumn<Map<String, dynamic>>(
@@ -24,7 +34,16 @@ Widget _table() {
     ],
     rowId: (r) => r['id'] as String,
     isSelectable: true,
-    onRowSelectionChanged: (_, __) {},
+    // Keep the header's select-all out of the tree so the only FlutterCheckbox
+    // is the row's. The header cell owns its own Material and is not the
+    // subject here.
+    theme: TablePlusTheme(
+      checkboxTheme: TablePlusCheckboxTheme(
+        showSelectAllCheckbox: false,
+        cellTapTogglesCheckbox: cellTapTogglesCheckbox,
+      ),
+    ),
+    onRowSelectionChanged: onRowSelectionChanged ?? (_, __) {},
     onSelectAll: (_) {},
   );
 }
@@ -39,6 +58,74 @@ void main() {
       isNull,
       reason: 'the table must not require a Material ancestor for its '
           'checkboxes (#3)',
+    );
+  });
+
+  testWidgets('tapping a row checkbox selects the row, with no Scaffold',
+      (tester) async {
+    final toggled = <String>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: _table(onRowSelectionChanged: (id, _) => toggled.add(id)),
+      ),
+    );
+
+    await tester.tap(find.byType(FlutterCheckbox));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.takeException(),
+      isNull,
+      reason: 'the checkbox splash needs a Material ancestor (#3)',
+    );
+    expect(toggled, ['1']);
+  });
+
+  testWidgets(
+      'tapping the selection cell toggles the checkbox, with no Scaffold',
+      (tester) async {
+    final toggled = <String>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: _table(
+          cellTapTogglesCheckbox: true,
+          onRowSelectionChanged: (id, _) => toggled.add(id),
+        ),
+      ),
+    );
+
+    // Just inside the cell's left edge — clear of the centred checkbox, so the
+    // cell's own InkWell handles the tap rather than the checkbox's.
+    final cell = tester.getRect(find.byType(TablePlusSelectionCell));
+    await tester.tapAt(Offset(cell.left + 2, cell.center.dy));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.takeException(),
+      isNull,
+      reason: "the cell-tap InkWell's splash needs a Material ancestor (#3)",
+    );
+    expect(toggled, ['1']);
+  });
+
+  testWidgets('hovering a row checkbox does not throw, with no Scaffold',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(home: _table()));
+
+    // Hover resolves `Material.of` through `updateHighlight`, a different code
+    // path from the tap splash.
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await mouse.addPointer(location: Offset.zero);
+    addTearDown(mouse.removePointer);
+    await tester.pump();
+
+    await mouse.moveTo(tester.getCenter(find.byType(FlutterCheckbox)));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.takeException(),
+      isNull,
+      reason: 'the checkbox hover highlight needs a Material ancestor (#3)',
     );
   });
 }


### PR DESCRIPTION
Closes #40. Follow-up to #38 (closed `wontfix`) and #41.

## What

`TablePlusSelectionCell` wrapped its checkbox in a transparent `Material`, and its cell-tap `InkWell` in another, so `FlutterCheckbox`'s internal `InkWell` would find a `Material` ancestor and the table would render without a `Scaffold` (#3).

`CustomInkWell` already wraps the whole row in one. The selection cell only renders when the row is selectable, and after #41 `tapSelect == isSelectable && selectionId != null` — with `rowId` typed `String Function(T)` and `groupId` non-null, a rendered selection cell always sits inside that row `Material`. Both nested ones were redundant.

A selection-enabled row goes from three `Material`s to one. Each is two render objects (`PhysicalModel` + `_InkFeatures`) plus two implicit-animation controllers (`AnimatedDefaultTextStyle`, `AnimatedPhysicalModel`).

Ink is still painted per row, so this is unrelated to the root-`Material` hoist rejected in #38 — that regressed scroll (p50 2.6 ms → 25 ms) by moving ink painting outside each row's `RepaintBoundary`.

## The #3 guard was passing for the wrong reason

`InkWell` resolves `Material.of` only when it paints ink — on tap (`_createSplash`, `ink_well.dart:1091`) and on hover/press (`updateHighlight`, `:1044`). A checkbox with no `Material` ancestor **builds fine** and throws only when touched.

The old guard pumped the table and asserted no exception. It passed — but because the row's `Ink` calls `Material.of` at build (`ink_decoration.dart:285`), not because of anything the checkbox does. Nothing exercised the checkbox's own ink paths, and `cellTapTogglesCheckbox` had no test at all. Had #38's idea of swapping `Ink` for a `ColoredBox` ever landed, the guard would have stayed green while #3 broke.

The guard now taps the checkbox, taps the selection cell, and hovers the checkbox — all inside a `MaterialApp` with no `Scaffold`. Verified sensitive: with the row `Material` removed, all three fail with `No Material widget found`.

## Release

Folded into the unreleased `2.14.0` rather than cut as a separate patch. README install pin follows.

`flutter analyze` clean, `flutter test` green (343).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
