### PR TITLE
chore: stop shipping working notes and build artifacts to pub.dev

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,14 +1,22 @@
 *.exe
 
+# Working notes, not part of the package.
 todo.md
+tip.md
 CLAUDE.md
+
+# Build and measurement artifacts.
 build/
+coverage/
+benchmark/
+
 example/build/
 example/windows/
 example/linux/
 example/android/
 example/ios/
 example/assets/
+
+# Read on GitHub, where their relative links resolve.
 docs/
-documentation/
 .github/


### PR DESCRIPTION
`tip.md` (Korean implementation notes on the scale feature), `coverage/` and `benchmark/` were all being uploaded to pub.dev.

`flutter pub publish --dry-run` reported **0 warnings** before and after. It validates the pubspec, the licence and the format — never what you chose to put in the archive. `.pubignore` is the only gate, and nothing tells you when it has a hole.

Also drops `documentation/`, a directory that does not exist. The same stale entry `CLAUDE.md` carried until b2bdc42.

`test/` stays: shipping tests is common and the archive is small.

Archive: 207 KB → 196 KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
