### PR TITLE
Drive the tooltip anchor from the playground panel

### DIFF
--- a/example/lib/pages/playground/playground_page.dart
+++ b/example/lib/pages/playground/playground_page.dart
@@ -960,156 +960,7 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
             );
           });
         },
-        theme: _buildTheme(),
-      ),
-    );
-  }
-
-  TextStyle _fontTextStyle({
-    double? fontSize,
-    Color? color,
-    FontWeight? fontWeight,
-  }) {
-    return switch (_settings.fontFamily) {
-      'pretendard' => TextStyle(
-          fontFamily: 'Pretendard',
-          fontSize: fontSize,
-          color: color,
-          fontWeight: fontWeight),
-      'notoSansKr' => GoogleFonts.notoSansKr(
-          fontSize: fontSize, color: color, fontWeight: fontWeight),
-      'inter' => GoogleFonts.inter(
-          fontSize: fontSize, color: color, fontWeight: fontWeight),
-      'firaCode' => GoogleFonts.firaCode(
-          fontSize: fontSize, color: color, fontWeight: fontWeight),
-      _ => TextStyle(fontSize: fontSize, color: color, fontWeight: fontWeight),
-    };
-  }
-
-  TablePlusTheme _buildTheme() {
-    return TablePlusTheme(
-      headerTheme: TablePlusHeaderTheme(
-        resizeHandle: TablePlusResizeHandleTheme(
-          width: _settings.resizeHandleWidth,
-          thickness: _settings.resizeHandleThickness,
-          indent: _settings.resizeHandleIndent,
-          endIndent: _settings.resizeHandleEndIndent,
-        ),
-        backgroundColor: Colors.blue.shade50,
-        topBorder: TablePlusHeaderBorderTheme(
-          show: _settings.headerTopBorderShow,
-          color: Colors.blue.shade200,
-          thickness: _settings.headerTopBorderThickness,
-        ),
-        bottomBorder: TablePlusHeaderBorderTheme(
-          show: _settings.headerBottomBorderShow,
-          color: Colors.grey.shade300,
-          thickness: _settings.headerBottomBorderThickness,
-        ),
-        verticalDivider: TablePlusHeaderDividerTheme(
-          show: _settings.headerVerticalDividerShow,
-          color: Colors.grey.shade300,
-          thickness: _settings.headerVerticalDividerThickness,
-          indent: _settings.headerVerticalDividerIndent,
-          endIndent: _settings.headerVerticalDividerEndIndent,
-        ),
-        textStyle: _fontTextStyle(
-          fontWeight: FontWeight.w600,
-          color: Colors.blue.shade800,
-          fontSize: _settings.fontSize,
-        ),
-        padding: EdgeInsets.symmetric(
-          horizontal: _settings.horizontalPadding,
-          vertical: _settings.verticalPadding,
-        ),
-        sortIcons: SortIcons(
-          ascending: SvgPicture.asset(
-            'assets/icons/up.svg',
-            width: _settings.sortIconWidth,
-            height: _settings.sortIconWidth,
-            colorFilter: ColorFilter.mode(
-              Colors.blue.shade700,
-              BlendMode.srcIn,
-            ),
-          ),
-          descending: SvgPicture.asset(
-            'assets/icons/down.svg',
-            width: _settings.sortIconWidth,
-            height: _settings.sortIconWidth,
-            colorFilter: ColorFilter.mode(
-              Colors.blue.shade700,
-              BlendMode.srcIn,
-            ),
-          ),
-          unsorted: SvgPicture.asset(
-            'assets/icons/upndown.svg',
-            width: _settings.sortIconWidth,
-            height: _settings.sortIconWidth,
-            colorFilter: const ColorFilter.mode(
-              Colors.grey,
-              BlendMode.srcIn,
-            ),
-          ),
-        ),
-        sortIconWidth: _settings.sortIconWidth,
-      ),
-      bodyTheme: TablePlusBodyTheme(
-        backgroundColor: Colors.white,
-        alternateRowColor: _settings.showAlternateRows
-            ? Colors.blue.shade50.withValues(alpha: 0.3)
-            : null,
-        textStyle: _fontTextStyle(
-          fontSize: _settings.fontSize,
-          color: Colors.black87,
-        ),
-        padding: EdgeInsets.symmetric(
-          horizontal: _settings.horizontalPadding,
-          vertical: _settings.verticalPadding,
-        ),
-        dividerColor:
-            _settings.showDividers ? Colors.grey.shade300 : Colors.transparent,
-        showHorizontalDividers: _settings.showDividers,
-        showVerticalDividers: _settings.showDividers,
-        selectedRowColor: Colors.blue.shade100.withValues(alpha: 0.6),
-        splashColor: _settings.splashColor.color,
-        hoverColor: _settings.hoverColor.color,
-        highlightColor: _settings.highlightColor.color,
-        rowHeight: _settings.rowHeight,
-      ),
-      editableTheme: TablePlusEditableTheme(
-        editingCellColor: Colors.yellow.shade100,
-        editingBorderColor: Colors.orange.shade400,
-        editingBorderWidth: 2.0,
-      ),
-      checkboxTheme: TablePlusCheckboxTheme(
-        showCheckboxColumn: _settings.showCheckboxColumn,
-        style: CheckboxStyle(
-          size: 18,
-          hoverRingPadding: _settings.checkboxTapTargetSize > 18
-              ? (_settings.checkboxTapTargetSize - 18) / 2
-              : 0,
-        ),
-        cellTapTogglesCheckbox: _settings.cellTapTogglesCheckbox,
-        showRowCheckbox: _settings.showRowCheckbox,
-      ),
-      // The card draws its own surface, so the tooltip must not draw one behind
-      // it. Text tooltips keep the styled surface from `tooltipTheme`.
-      rowTooltipTheme: TablePlusTooltipTheme(
-        enabled: _settings.tooltipEnabled,
-        waitDuration: Duration(milliseconds: _settings.tooltipWaitDurationMs),
-        backgroundColor: Colors.transparent,
-        padding: EdgeInsets.zero,
-        elevation: 0,
-        showArrow: false,
-      ),
-      tooltipTheme: TablePlusTooltipTheme(
-        enabled: _settings.tooltipEnabled,
-        waitDuration: Duration(milliseconds: _settings.tooltipWaitDurationMs),
-        textStyle: _fontTextStyle(fontSize: 12, color: Colors.white),
-        direction: _settings.tooltipDirection,
-        alignment: _settings.tooltipAlignment,
-        showArrow: _settings.tooltipShowArrow,
-        offset: _settings.tooltipOffset,
+        theme: buildPlaygroundTheme(_settings),
       ),
     );
   }
@@ -1134,4 +985,160 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
     }
     return number.toString();
   }
+}
+
+/// The table theme the playground builds from its [PlaygroundSettings].
+///
+/// Free of `BuildContext` and of widget state, so it can be asserted on
+/// directly: what the panel selects is exactly what the table receives.
+TextStyle _fontTextStyle(
+  PlaygroundSettings settings, {
+  double? fontSize,
+  Color? color,
+  FontWeight? fontWeight,
+}) {
+  return switch (settings.fontFamily) {
+    'pretendard' => TextStyle(
+        fontFamily: 'Pretendard',
+        fontSize: fontSize,
+        color: color,
+        fontWeight: fontWeight),
+    'notoSansKr' => GoogleFonts.notoSansKr(
+        fontSize: fontSize, color: color, fontWeight: fontWeight),
+    'inter' => GoogleFonts.inter(
+        fontSize: fontSize, color: color, fontWeight: fontWeight),
+    'firaCode' => GoogleFonts.firaCode(
+        fontSize: fontSize, color: color, fontWeight: fontWeight),
+    _ => TextStyle(fontSize: fontSize, color: color, fontWeight: fontWeight),
+  };
+}
+
+TablePlusTheme buildPlaygroundTheme(PlaygroundSettings settings) {
+  return TablePlusTheme(
+    headerTheme: TablePlusHeaderTheme(
+      resizeHandle: TablePlusResizeHandleTheme(
+        width: settings.resizeHandleWidth,
+        thickness: settings.resizeHandleThickness,
+        indent: settings.resizeHandleIndent,
+        endIndent: settings.resizeHandleEndIndent,
+      ),
+      backgroundColor: Colors.blue.shade50,
+      topBorder: TablePlusHeaderBorderTheme(
+        show: settings.headerTopBorderShow,
+        color: Colors.blue.shade200,
+        thickness: settings.headerTopBorderThickness,
+      ),
+      bottomBorder: TablePlusHeaderBorderTheme(
+        show: settings.headerBottomBorderShow,
+        color: Colors.grey.shade300,
+        thickness: settings.headerBottomBorderThickness,
+      ),
+      verticalDivider: TablePlusHeaderDividerTheme(
+        show: settings.headerVerticalDividerShow,
+        color: Colors.grey.shade300,
+        thickness: settings.headerVerticalDividerThickness,
+        indent: settings.headerVerticalDividerIndent,
+        endIndent: settings.headerVerticalDividerEndIndent,
+      ),
+      textStyle: _fontTextStyle(
+        settings,
+        fontWeight: FontWeight.w600,
+        color: Colors.blue.shade800,
+        fontSize: settings.fontSize,
+      ),
+      padding: EdgeInsets.symmetric(
+        horizontal: settings.horizontalPadding,
+        vertical: settings.verticalPadding,
+      ),
+      sortIcons: SortIcons(
+        ascending: SvgPicture.asset(
+          'assets/icons/up.svg',
+          width: settings.sortIconWidth,
+          height: settings.sortIconWidth,
+          colorFilter: ColorFilter.mode(
+            Colors.blue.shade700,
+            BlendMode.srcIn,
+          ),
+        ),
+        descending: SvgPicture.asset(
+          'assets/icons/down.svg',
+          width: settings.sortIconWidth,
+          height: settings.sortIconWidth,
+          colorFilter: ColorFilter.mode(
+            Colors.blue.shade700,
+            BlendMode.srcIn,
+          ),
+        ),
+        unsorted: SvgPicture.asset(
+          'assets/icons/upndown.svg',
+          width: settings.sortIconWidth,
+          height: settings.sortIconWidth,
+          colorFilter: const ColorFilter.mode(
+            Colors.grey,
+            BlendMode.srcIn,
+          ),
+        ),
+      ),
+      sortIconWidth: settings.sortIconWidth,
+    ),
+    bodyTheme: TablePlusBodyTheme(
+      backgroundColor: Colors.white,
+      alternateRowColor: settings.showAlternateRows
+          ? Colors.blue.shade50.withValues(alpha: 0.3)
+          : null,
+      textStyle: _fontTextStyle(
+        settings,
+        fontSize: settings.fontSize,
+        color: Colors.black87,
+      ),
+      padding: EdgeInsets.symmetric(
+        horizontal: settings.horizontalPadding,
+        vertical: settings.verticalPadding,
+      ),
+      dividerColor:
+          settings.showDividers ? Colors.grey.shade300 : Colors.transparent,
+      showHorizontalDividers: settings.showDividers,
+      showVerticalDividers: settings.showDividers,
+      selectedRowColor: Colors.blue.shade100.withValues(alpha: 0.6),
+      splashColor: settings.splashColor.color,
+      hoverColor: settings.hoverColor.color,
+      highlightColor: settings.highlightColor.color,
+      rowHeight: settings.rowHeight,
+    ),
+    editableTheme: TablePlusEditableTheme(
+      editingCellColor: Colors.yellow.shade100,
+      editingBorderColor: Colors.orange.shade400,
+      editingBorderWidth: 2.0,
+    ),
+    checkboxTheme: TablePlusCheckboxTheme(
+      showCheckboxColumn: settings.showCheckboxColumn,
+      style: CheckboxStyle(
+        size: 18,
+        hoverRingPadding: settings.checkboxTapTargetSize > 18
+            ? (settings.checkboxTapTargetSize - 18) / 2
+            : 0,
+      ),
+      cellTapTogglesCheckbox: settings.cellTapTogglesCheckbox,
+      showRowCheckbox: settings.showRowCheckbox,
+    ),
+    // The card draws its own surface, so the tooltip must not draw one behind
+    // it. Text tooltips keep the styled surface from `tooltipTheme`.
+    rowTooltipTheme: TablePlusTooltipTheme(
+      enabled: settings.tooltipEnabled,
+      waitDuration: Duration(milliseconds: settings.tooltipWaitDurationMs),
+      backgroundColor: Colors.transparent,
+      padding: EdgeInsets.zero,
+      elevation: 0,
+      showArrow: false,
+    ),
+    tooltipTheme: TablePlusTooltipTheme(
+      enabled: settings.tooltipEnabled,
+      waitDuration: Duration(milliseconds: settings.tooltipWaitDurationMs),
+      textStyle: _fontTextStyle(settings, fontSize: 12, color: Colors.white),
+      direction: settings.tooltipDirection,
+      alignment: settings.tooltipAlignment,
+      showArrow: settings.tooltipShowArrow,
+      offset: settings.tooltipOffset,
+    ),
+  );
 }

--- a/example/lib/pages/playground/playground_page.dart
+++ b/example/lib/pages/playground/playground_page.dart
@@ -1014,6 +1014,16 @@ TextStyle _fontTextStyle(
 }
 
 TablePlusTheme buildPlaygroundTheme(PlaygroundSettings settings) {
+  final cellTooltip = TablePlusTooltipTheme(
+    enabled: settings.tooltipEnabled,
+    waitDuration: Duration(milliseconds: settings.tooltipWaitDurationMs),
+    textStyle: _fontTextStyle(settings, fontSize: 12, color: Colors.white),
+    direction: settings.tooltipDirection,
+    alignment: settings.tooltipAlignment,
+    showArrow: settings.tooltipShowArrow,
+    offset: settings.tooltipOffset,
+    anchor: settings.tooltipAnchor,
+  );
   return TablePlusTheme(
     headerTheme: TablePlusHeaderTheme(
       resizeHandle: TablePlusResizeHandleTheme(
@@ -1131,14 +1141,16 @@ TablePlusTheme buildPlaygroundTheme(PlaygroundSettings settings) {
       elevation: 0,
       showArrow: false,
     ),
-    tooltipTheme: TablePlusTooltipTheme(
-      enabled: settings.tooltipEnabled,
-      waitDuration: Duration(milliseconds: settings.tooltipWaitDurationMs),
-      textStyle: _fontTextStyle(settings, fontSize: 12, color: Colors.white),
-      direction: settings.tooltipDirection,
-      alignment: settings.tooltipAlignment,
-      showArrow: settings.tooltipShowArrow,
-      offset: settings.tooltipOffset,
-    ),
+    tooltipTheme: cellTooltip,
+    // Null while the header follows the cells, so the package's documented
+    // fallback to `tooltipTheme` is the path the playground normally walks.
+    // The two themes differ in nothing but the anchor.
+    headerTooltipTheme: switch (settings.headerTooltipAnchor) {
+      HeaderTooltipAnchor.followCells => null,
+      HeaderTooltipAnchor.child =>
+        cellTooltip.copyWith(anchor: TooltipAnchor.child),
+      HeaderTooltipAnchor.pointer =>
+        cellTooltip.copyWith(anchor: TooltipAnchor.pointer),
+    },
   );
 }

--- a/example/lib/pages/playground/widgets/settings_panel.dart
+++ b/example/lib/pages/playground/widgets/settings_panel.dart
@@ -25,6 +25,15 @@ enum InkColorOption {
 }
 
 /// Playground settings configuration
+/// Where header tooltips anchor, as the settings panel offers it.
+///
+/// [followCells] passes `null` through, leaving `TablePlusTheme
+/// .headerTooltipTheme` unset so the table falls back to `tooltipTheme`. It is
+/// the default because a playground that never walks the fallback would not
+/// show it working. The other two hand the header a theme of its own, which is
+/// the only way to anchor a header differently from the cells beneath it.
+enum HeaderTooltipAnchor { followCells, child, pointer }
+
 class PlaygroundSettings {
   // Data settings
   final int rowCount;
@@ -73,6 +82,12 @@ class PlaygroundSettings {
   final TooltipAlignment tooltipAlignment;
   final bool tooltipShowArrow;
   final double tooltipOffset;
+
+  /// Where cell tooltips are anchored.
+  final TooltipAnchor tooltipAnchor;
+
+  /// Where header tooltips are anchored.
+  final HeaderTooltipAnchor headerTooltipAnchor;
 
   // Font settings
   final String fontFamily;
@@ -140,6 +155,8 @@ class PlaygroundSettings {
     this.tooltipAlignment = TooltipAlignment.center,
     this.tooltipShowArrow = false,
     this.tooltipOffset = 8.0,
+    this.tooltipAnchor = TooltipAnchor.child,
+    this.headerTooltipAnchor = HeaderTooltipAnchor.followCells,
     this.fontFamily = 'default',
     this.headerTopBorderShow = true,
     this.headerTopBorderThickness = 2.0,
@@ -196,6 +213,8 @@ class PlaygroundSettings {
     bool? showTooltipBuilder,
     TooltipDirection? tooltipDirection,
     TooltipAlignment? tooltipAlignment,
+    TooltipAnchor? tooltipAnchor,
+    HeaderTooltipAnchor? headerTooltipAnchor,
     bool? tooltipShowArrow,
     double? tooltipOffset,
     String? fontFamily,
@@ -257,6 +276,8 @@ class PlaygroundSettings {
       showTooltipBuilder: showTooltipBuilder ?? this.showTooltipBuilder,
       tooltipDirection: tooltipDirection ?? this.tooltipDirection,
       tooltipAlignment: tooltipAlignment ?? this.tooltipAlignment,
+      tooltipAnchor: tooltipAnchor ?? this.tooltipAnchor,
+      headerTooltipAnchor: headerTooltipAnchor ?? this.headerTooltipAnchor,
       tooltipShowArrow: tooltipShowArrow ?? this.tooltipShowArrow,
       tooltipOffset: tooltipOffset ?? this.tooltipOffset,
       fontFamily: fontFamily ?? this.fontFamily,
@@ -1180,6 +1201,43 @@ class SettingsPanel extends StatelessWidget {
           ),
           const SizedBox(height: 4),
 
+          // Anchor — cells
+          _buildDropdownRow<TooltipAnchor>(
+            label: 'Cell Anchor',
+            value: settings.tooltipAnchor,
+            items: TooltipAnchor.values,
+            itemLabel: (a) => switch (a) {
+              TooltipAnchor.child => 'Child',
+              TooltipAnchor.pointer => 'Pointer',
+            },
+            onChanged: (value) {
+              onSettingsChanged(settings.copyWith(tooltipAnchor: value));
+            },
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: 8, bottom: 4),
+            child: Text(
+              'The row card always anchors at the pointer; it ignores this',
+              style: TextStyle(fontSize: 11, color: Colors.grey.shade600),
+            ),
+          ),
+
+          // Anchor — headers
+          _buildDropdownRow<HeaderTooltipAnchor>(
+            label: 'Header Anchor',
+            value: settings.headerTooltipAnchor,
+            items: HeaderTooltipAnchor.values,
+            itemLabel: (a) => switch (a) {
+              HeaderTooltipAnchor.followCells => 'Follow Cells',
+              HeaderTooltipAnchor.child => 'Child',
+              HeaderTooltipAnchor.pointer => 'Pointer',
+            },
+            onChanged: (value) {
+              onSettingsChanged(settings.copyWith(headerTooltipAnchor: value));
+            },
+          ),
+          const SizedBox(height: 4),
+
           // Alignment
           _buildDropdownRow<TooltipAlignment>(
             label: 'Alignment',
@@ -1196,7 +1254,16 @@ class SettingsPanel extends StatelessWidget {
               onSettingsChanged(settings.copyWith(tooltipAlignment: value));
             },
           ),
-          const SizedBox(height: 4),
+          Padding(
+            padding: const EdgeInsets.only(left: 8, bottom: 4),
+            child: Text(
+              settings.tooltipAnchor == TooltipAnchor.pointer
+                  ? "Against the pointer there are no target edges, so this "
+                      "picks which of the tooltip's own edges lands on the cursor"
+                  : 'Picks which edge of the target the tooltip lines up with',
+              style: TextStyle(fontSize: 11, color: Colors.grey.shade600),
+            ),
+          ),
 
           // Show Arrow
           _buildSwitchTile(

--- a/example/test/playground_theme_test.dart
+++ b/example/test/playground_theme_test.dart
@@ -1,0 +1,62 @@
+import 'package:example/pages/playground/playground_page.dart';
+import 'package:example/pages/playground/widgets/settings_panel.dart';
+import 'package:flutter_table_plus/flutter_table_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PlaygroundSettings', () {
+    test('anchors cell tooltips on the child until told otherwise', () {
+      expect(const PlaygroundSettings().tooltipAnchor, TooltipAnchor.child);
+    });
+
+    test('copyWith carries the tooltip anchor', () {
+      const settings = PlaygroundSettings();
+      final c = settings.copyWith(tooltipAnchor: TooltipAnchor.pointer);
+      expect(c.tooltipAnchor, TooltipAnchor.pointer);
+      expect(c.copyWith().tooltipAnchor, TooltipAnchor.pointer);
+      expect(c.tooltipAlignment, settings.tooltipAlignment);
+    });
+  });
+
+  group('buildPlaygroundTheme', () {
+    test('the cell anchor reaches the table theme', () {
+      final theme = buildPlaygroundTheme(
+        const PlaygroundSettings(tooltipAnchor: TooltipAnchor.pointer),
+      );
+      expect(theme.tooltipTheme.anchor, TooltipAnchor.pointer);
+    });
+
+    test('leaves the header tooltip theme unset while it follows the cells',
+        () {
+      // Null is the whole point: it selects the package's documented fallback
+      // to tooltipTheme, so the playground walks that path unless a user
+      // deliberately steps off it. Handing the header its own theme eagerly
+      // would leave the fallback unexercised while everything still looked
+      // right on screen.
+      expect(
+          buildPlaygroundTheme(const PlaygroundSettings()).headerTooltipTheme,
+          isNull);
+    });
+
+    test('a chosen header anchor gives the header a theme of its own', () {
+      final theme = buildPlaygroundTheme(
+        const PlaygroundSettings(
+            headerTooltipAnchor: HeaderTooltipAnchor.pointer),
+      );
+      expect(theme.headerTooltipTheme?.anchor, TooltipAnchor.pointer);
+      expect(theme.tooltipTheme.anchor, TooltipAnchor.child,
+          reason: 'the cell anchor is untouched by the header one');
+    });
+
+    test('the header can return to following the cells', () {
+      // A dropdown must be able to walk back. `copyWith`'s `?? this.x` idiom
+      // cannot restore a null, which is why the panel models this as a third
+      // enum value rather than a nullable anchor.
+      const settings =
+          PlaygroundSettings(headerTooltipAnchor: HeaderTooltipAnchor.pointer);
+      final back = settings.copyWith(
+          headerTooltipAnchor: HeaderTooltipAnchor.followCells);
+      expect(buildPlaygroundTheme(back).headerTooltipTheme, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Closes #54

`TooltipAnchor` landed in #51 and `headerTooltipTheme` in #52, but neither is reachable from the example. Anchor is the kind of setting whose value is obvious in one hover and opaque in prose, so the playground now offers both, and the two interact: the headline demonstration is anchoring headers at the pointer while cells stay on their child, which no single control can show.

## What's here

A **Cell Anchor** dropdown (`Child` / `Pointer`) and a **Header Anchor** dropdown (`Follow Cells` / `Child` / `Pointer`), threaded through `PlaygroundSettings` and its `copyWith` alongside the existing `tooltipDirection` and `tooltipAlignment`.

`Follow Cells` is the default, and it leaves `headerTooltipTheme` null. That is deliberate: it makes the demo walk the package's documented fallback to `tooltipTheme` on every ordinary run, rather than only when someone goes looking for it. A test holds that line — handing the header its own theme eagerly would leave the fallback unexercised while the screen still looked right.

The panel also says what the anchor does **not** reach. The row card built by `rowTooltipBuilder` always anchors at the pointer and ignores the setting, so a hint under Cell Anchor says so; without it, a toggle that visibly moves cell tooltips but not the card reads as a bug. A second hint explains that `alignment` changes meaning under `Pointer` — against a point there are no target edges to align to, so the alignment picks one of the tooltip's own — and it rewrites itself as the anchor changes. Both notes sit where the control is, not in a doc nobody opens while dragging a dropdown.

## Two things the work taught

**A nullable anchor did not survive contact with the dropdown.** Modelling the header choice as `TooltipAnchor?` mirrored the package exactly and passed its unit tests, but `copyWith`'s `?? this.x` idiom cannot restore a null: picking `Follow Cells` after `Pointer` would have silently done nothing. It is a three-value enum instead, mirroring the `InkColorChoice.themeDefault` idiom already in that file, where the sentinel value is the one that passes null through. A test now pins that the header can walk back.

**`_buildTheme()` never needed widget state.** It read `_settings` and never `BuildContext`, so it was a method only because of where it was written. Hoisted to a top-level `buildPlaygroundTheme(PlaygroundSettings)` in its own commit — a pure move — what the panel selects can now be asserted against what the table receives, without pumping a 36 KB page.

## Verification

`cd example && flutter analyze` is clean, `dart format` leaves the example unchanged, and the six new tests in `example/test/playground_theme_test.dart` pass. The package's own 378 tests are untouched and still green. Each new test was checked to actually fail without its production change.

The panel itself has **not** been verified on screen — that needs a human to run the app. `example/test/widget_test.dart` remains red on `main`, which is a pre-existing failure deliberately left alone; it is filed as #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)