### PR TITLE
Make the example's widget test true, and fix the layout it caught

### DIFF
--- a/example/lib/pages/playground/widgets/performance_monitor.dart
+++ b/example/lib/pages/playground/widgets/performance_monitor.dart
@@ -64,12 +64,18 @@ class PerformanceMonitor extends StatelessWidget {
             children: [
               Icon(Icons.speed, color: Colors.blue.shade700, size: 20),
               const SizedBox(width: 8),
-              Text(
-                'Performance Metrics',
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  color: Colors.blue.shade700,
+              // The panel is a fixed 380 wide, so the title has to yield rather
+              // than overflow when the text grows — a larger accessibility text
+              // scale, or a translation, will do it.
+              Expanded(
+                child: Text(
+                  'Performance Metrics',
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                    color: Colors.blue.shade700,
+                  ),
                 ),
               ),
             ],

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1,30 +1,18 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
+import 'package:example/main.dart';
+import 'package:example/pages/playground/models/employee.dart';
+import 'package:flutter_table_plus/flutter_table_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:example/main.dart';
+// A smoke test for the example app: the playground builds, lays out, and paints
+// a table. `pumpWidget` and `pumpAndSettle` rethrow anything the framework
+// caught, so an overflow or a build-time throw fails this outright.
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('the playground renders its table', (tester) async {
     await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle(); // the playground generates its rows async
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.byType(FlutterTablePlus<Employee>), findsOneWidget);
+    expect(find.text('Name'), findsOneWidget, reason: 'a header cell painted');
   });
 }


### PR DESCRIPTION
Closes #55

`example/test/widget_test.dart` was the counter test `flutter create` scaffolds: pump `MyApp`, find `0`, tap an add icon, expect `1`. The example has never been a counter — `MyApp` renders `PlaygroundPage` — so `cd example && flutter test` has been red for as long as the file has existed. A permanently red test is worse than none: it trains everyone to stop running the command, and it hides the day something real breaks.

It now pumps `MyApp` and asserts the playground rendered its table.

## The test found a real bug, not a test problem

`PerformanceMonitor`'s title row put an `Icon` and an unbounded `Text` in a `Row`, inside a settings panel fixed at `width: 380`. The `Row` overflowed by 32px.

Widening the test surface could not fix it — the panel's width does not depend on the window's, which the failure spelled out in `constraints: BoxConstraints(0.0<=w<=305.0)` no matter how large the view got.

The arithmetic explains why it went unseen. Under a real font `'Performance Metrics'` measures ~190px and fits. Under the test font every glyph is a square of the font size, so 19 characters × 16px = 304px, plus a 20px icon and an 8px gap = 332px, and the `Row` bursts by exactly the 32px reported. The test font is not being awkward here; it is a worst-case width simulator, and it found a fragility the real app shares: the same overflow appears whenever the text grows, whether from a larger accessibility text scale or a translation.

So the title is now `Expanded` and ellipsizes. With that fixed, the playground lays out at the default 800×600 surface and the smoke test needs no view sizing at all. Removing the `Expanded` again reproduces the overflow and fails the test, which is the point of keeping it.

## Verification

`cd example && flutter test` is green for the first time (7 tests). The package's 378 tests are untouched and still green. `flutter analyze` is clean in both, and `dart format` leaves both unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)