### PR TITLE
Open the example on a list of demos, not on the playground

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'pages/playground/playground_page.dart';
+import 'pages/home_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -11,13 +11,13 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'FlutterTablePlus Playground',
+      title: 'FlutterTablePlus Examples',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
         primarySwatch: Colors.blue,
         useMaterial3: true,
       ),
-      home: const PlaygroundPage(),
+      home: const HomePage(),
     );
   }
 }

--- a/example/lib/pages/home_page.dart
+++ b/example/lib/pages/home_page.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import 'playground/playground_page.dart';
+
+/// Lists the demos this example ships, so a reader after one feature does not
+/// have to find it inside a page that shows them all.
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('FlutterTablePlus Examples')),
+      body: ListView(
+        children: [
+          ListTile(
+            leading: const Icon(Icons.tune),
+            title: const Text('Playground'),
+            // The test font measures every glyph as a square of the font size,
+            // so this line is far wider under test than on screen. Let it
+            // ellipsize rather than overflow.
+            subtitle: const Text(
+              'Every feature at once, with a knob for each',
+              overflow: TextOverflow.ellipsis,
+            ),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => const PlaygroundPage(),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -3,14 +3,30 @@ import 'package:example/pages/playground/models/employee.dart';
 import 'package:flutter_table_plus/flutter_table_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-// A smoke test for the example app: the playground builds, lays out, and paints
-// a table. `pumpWidget` and `pumpAndSettle` rethrow anything the framework
-// caught, so an overflow or a build-time throw fails this outright.
+// Smoke tests for the example app. `pumpWidget` and `pumpAndSettle` rethrow
+// whatever the framework caught, so a build-time throw or an overflow fails
+// these outright — which is how the layout bug in #55 surfaced.
 
 void main() {
-  testWidgets('the playground renders its table', (tester) async {
+  testWidgets('the app opens on a list of demos', (tester) async {
     await tester.pumpWidget(const MyApp());
-    await tester.pumpAndSettle(); // the playground generates its rows async
+    await tester.pumpAndSettle();
+
+    // The settings panel also paints the word 'Playground', so the entry's
+    // description is what tells the home apart from the demo it links to.
+    expect(find.text('Playground'), findsOneWidget);
+    expect(find.text('Every feature at once, with a knob for each'),
+        findsOneWidget);
+    expect(find.byType(FlutterTablePlus<Employee>), findsNothing,
+        reason: 'the home lists demos; it does not host one');
+  });
+
+  testWidgets('opening the playground renders its table', (tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Playground'));
+    await tester.pumpAndSettle(); // route transition, then async row generation
 
     expect(find.byType(FlutterTablePlus<Employee>), findsOneWidget);
     expect(find.text('Name'), findsOneWidget, reason: 'a header cell painted');


### PR DESCRIPTION
Closes #58

The example went straight into the playground — a page that turns on every feature at once. That is a fine thing to have and a poor thing to land on: a reader after one feature has nowhere else to go, and the playground's own purpose (turn everything on, stress it) is at odds with being the first thing anyone meets.

`MyApp` now opens on a home listing the demos, with the playground as its single entry. The playground itself is untouched.

## The old smoke test could not simply move

`example/test/widget_test.dart` is the example's only integration test, and it went green for the first time only in #55. Changing the root breaks its premise, so it is updated here rather than left red for a later issue.

Writing it turned up something worth keeping: `find.text('Playground')` **passed before the home existed**. The settings panel paints that exact word as its header, so the assertion could never have proved a home was there. The entry's description line is what distinguishes the two, so the test asserts that instead. The old assertion about the table now runs after tapping through to the playground, which is where it is true.

## No abstraction for demos that do not exist yet

The home holds one `ListTile`. #61 adds the second demo; that is when the two will have a shape in common worth extracting. An abstraction pulled from a one-item list rarely fits the second item.

## Verification

`cd example && flutter test` passes (8 tests), the package's 378 are untouched and green, `flutter analyze` is clean in both, and `dart format` leaves both unchanged. The navigation test was checked to fail when the entry's `onTap` is removed.

The description line is the kind of text that overflows only under test, where every glyph is a square of the font size (#55). It ellipsizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)