### PR TITLE
A demo page that shows only tooltip anchoring

### DIFF
--- a/example/lib/pages/home_page.dart
+++ b/example/lib/pages/home_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'playground/playground_page.dart';
+import 'tooltip_anchor/tooltip_anchor_page.dart';
 
 /// Lists the demos this example ships, so a reader after one feature does not
 /// have to find it inside a page that shows them all.
@@ -13,24 +14,50 @@ class HomePage extends StatelessWidget {
       appBar: AppBar(title: const Text('FlutterTablePlus Examples')),
       body: ListView(
         children: [
-          ListTile(
-            leading: const Icon(Icons.tune),
-            title: const Text('Playground'),
-            // The test font measures every glyph as a square of the font size,
-            // so this line is far wider under test than on screen. Let it
-            // ellipsize rather than overflow.
-            subtitle: const Text(
-              'Every feature at once, with a knob for each',
-              overflow: TextOverflow.ellipsis,
-            ),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () => Navigator.of(context).push(
-              MaterialPageRoute<void>(
-                builder: (_) => const PlaygroundPage(),
-              ),
-            ),
+          _DemoTile(
+            icon: Icons.tune,
+            title: 'Playground',
+            summary: 'Every feature at once, with a knob for each',
+            open: () => const PlaygroundPage(),
+          ),
+          _DemoTile(
+            icon: Icons.my_location,
+            title: 'Tooltip anchors',
+            summary: 'Where a tooltip sits: beside the cell, or beside the '
+                'cursor',
+            open: () => const TooltipAnchorPage(),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _DemoTile extends StatelessWidget {
+  const _DemoTile({
+    required this.icon,
+    required this.title,
+    required this.summary,
+    required this.open,
+  });
+
+  final IconData icon;
+  final String title;
+  final String summary;
+  final Widget Function() open;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(icon),
+      title: Text(title),
+      // The test font measures every glyph as a square of the font size, so a
+      // summary is far wider under test than on screen. Let it ellipsize
+      // rather than overflow.
+      subtitle: Text(summary, overflow: TextOverflow.ellipsis),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () => Navigator.of(context).push(
+        MaterialPageRoute<void>(builder: (_) => open()),
       ),
     );
   }

--- a/example/lib/pages/tooltip_anchor/tooltip_anchor_page.dart
+++ b/example/lib/pages/tooltip_anchor/tooltip_anchor_page.dart
@@ -1,0 +1,240 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_table_plus/flutter_table_plus.dart';
+
+/// One row of the anchor demo. The value is long on purpose: a text tooltip's
+/// hover target is the `Text` itself, so a short value leaves the child's
+/// centre and the cursor a few pixels apart and both anchors look alike.
+class TooltipAnchorRow {
+  const TooltipAnchorRow({required this.id, required this.value});
+
+  final String id;
+  final String value;
+}
+
+/// Where header tooltips anchor, as this demo offers it.
+///
+/// [followCells] passes `null` through, leaving `TablePlusTheme
+/// .headerTooltipTheme` unset so the table falls back to `tooltipTheme`. It is
+/// the default because a demo that never walks the fallback would not show it
+/// working. The other two hand the header a theme of its own, which is the only
+/// way to anchor a header differently from the cells beneath it.
+enum HeaderAnchorChoice { followCells, child, pointer }
+
+/// The theme the demo builds from its two anchor choices.
+///
+/// Free of `BuildContext` and of widget state, so what the controls select can
+/// be asserted directly against what the table receives.
+TablePlusTheme buildAnchorDemoTheme({
+  TooltipAnchor cellAnchor = TooltipAnchor.child,
+  HeaderAnchorChoice headerAnchor = HeaderAnchorChoice.followCells,
+}) {
+  final cellTooltip = TablePlusTooltipTheme(anchor: cellAnchor);
+
+  return TablePlusTheme(
+    tooltipTheme: cellTooltip,
+    headerTooltipTheme: switch (headerAnchor) {
+      HeaderAnchorChoice.followCells => null,
+      HeaderAnchorChoice.child =>
+        cellTooltip.copyWith(anchor: TooltipAnchor.child),
+      HeaderAnchorChoice.pointer =>
+        cellTooltip.copyWith(anchor: TooltipAnchor.pointer),
+    },
+    rowTooltipTheme: const TablePlusTooltipTheme(
+      backgroundColor: Colors.transparent,
+      padding: EdgeInsets.zero,
+      elevation: 0,
+    ),
+  );
+}
+
+const _rows = [
+  TooltipAnchorRow(
+    id: '1',
+    value: 'a value long enough that the column has to cut it short',
+  ),
+  TooltipAnchorRow(
+    id: '2',
+    value: 'another value the column cannot possibly show in full',
+  ),
+  TooltipAnchorRow(
+    id: '3',
+    value: 'a third that also runs past the edge of its cell',
+  ),
+];
+
+class TooltipAnchorPage extends StatefulWidget {
+  const TooltipAnchorPage({super.key});
+
+  @override
+  State<TooltipAnchorPage> createState() => _TooltipAnchorPageState();
+}
+
+class _TooltipAnchorPageState extends State<TooltipAnchorPage> {
+  TooltipAnchor _cellAnchor = TooltipAnchor.child;
+  HeaderAnchorChoice _headerAnchor = HeaderAnchorChoice.followCells;
+
+  Map<String, TablePlusColumn<TooltipAnchorRow>> get _columns =>
+      TableColumnsBuilder<TooltipAnchorRow>()
+          .addColumn(
+            'value',
+            TablePlusColumn<TooltipAnchorRow>(
+              key: 'value',
+              label: 'A heading long enough to be cut short as well',
+              order: 0,
+              width: 260,
+              maxWidth: 260,
+              valueAccessor: (row) => row.value,
+              // Both tooltips only appear once their text is truncated, which
+              // is also the only state in which the two anchors are far enough
+              // apart to tell apart.
+              tooltipBehavior: TooltipBehavior.onlyTextOverflow,
+              headerTooltipBehavior: TooltipBehavior.onlyTextOverflow,
+            ),
+          )
+          .addColumn(
+            'id',
+            TablePlusColumn<TooltipAnchorRow>(
+              key: 'id',
+              label: '#',
+              order: 1,
+              width: 80,
+              valueAccessor: (row) => row.id,
+            ),
+          )
+          .build();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Tooltip anchors')),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Wrap(
+                  spacing: 24,
+                  runSpacing: 12,
+                  children: [
+                    _AnchorChoice<TooltipAnchor>(
+                      label: 'Cell anchor',
+                      value: _cellAnchor,
+                      values: TooltipAnchor.values,
+                      nameOf: (a) => a.name,
+                      onChanged: (a) => setState(() => _cellAnchor = a),
+                    ),
+                    _AnchorChoice<HeaderAnchorChoice>(
+                      label: 'Header anchor',
+                      value: _headerAnchor,
+                      values: HeaderAnchorChoice.values,
+                      nameOf: (a) => switch (a) {
+                        HeaderAnchorChoice.followCells => 'follow cells',
+                        HeaderAnchorChoice.child => 'child',
+                        HeaderAnchorChoice.pointer => 'pointer',
+                      },
+                      onChanged: (a) => setState(() => _headerAnchor = a),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                const _Note(
+                  'Hover the truncated value, then its heading. `child` puts '
+                  'the tooltip at the middle of what you hovered; `pointer` '
+                  'puts it beside the cursor.',
+                ),
+                const _Note(
+                  'Leave the header on `follow cells` and it takes the cell '
+                  'anchor — that is the theme falling back, not a copy.',
+                ),
+                const _Note(
+                  'The row card ignores both. A row is as wide as the table\'s '
+                  'content, so anchoring to it would aim at a point that can '
+                  'be off screen; it always anchors at the pointer.',
+                ),
+                const _Note(
+                  'Alignment changes meaning with the anchor. Against a point '
+                  'there are no target edges to line up with, so it picks '
+                  'which of the tooltip\'s own edges lands on the cursor.',
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: FlutterTablePlus<TooltipAnchorRow>(
+              columns: _columns,
+              data: _rows,
+              rowId: (row) => row.id,
+              theme: buildAnchorDemoTheme(
+                cellAnchor: _cellAnchor,
+                headerAnchor: _headerAnchor,
+              ),
+              rowTooltipBuilder: (context, row) => Card(
+                margin: EdgeInsets.zero,
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Text('Row ${row.id}'),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A labelled set of radio choices, laid out so a long label wraps instead of
+/// overflowing — the test font makes every glyph a square of the font size.
+class _AnchorChoice<T> extends StatelessWidget {
+  const _AnchorChoice({
+    required this.label,
+    required this.value,
+    required this.values,
+    required this.nameOf,
+    required this.onChanged,
+  });
+
+  final String label;
+  final T value;
+  final List<T> values;
+  final String Function(T) nameOf;
+  final ValueChanged<T> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: Theme.of(context).textTheme.labelLarge),
+        Wrap(
+          spacing: 8,
+          children: [
+            for (final v in values)
+              ChoiceChip(
+                label: Text(nameOf(v)),
+                selected: v == value,
+                onSelected: (picked) => picked ? onChanged(v) : null,
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _Note extends StatelessWidget {
+  const _Note(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Text(text, style: Theme.of(context).textTheme.bodySmall),
+    );
+  }
+}

--- a/example/test/tooltip_anchor_demo_test.dart
+++ b/example/test/tooltip_anchor_demo_test.dart
@@ -1,0 +1,45 @@
+import 'package:example/pages/tooltip_anchor/tooltip_anchor_page.dart';
+import 'package:flutter_table_plus/flutter_table_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// The demo's only logic is turning two anchor choices into a TablePlusTheme.
+// Whether a tooltip then lands beside the cursor is the package's business, and
+// it is pinned there — repeating it here would test just_tooltip twice.
+
+void main() {
+  test('cells anchor on the child until told otherwise', () {
+    final theme = buildAnchorDemoTheme();
+    expect(theme.tooltipTheme.anchor, TooltipAnchor.child);
+  });
+
+  test('the cell anchor reaches the theme', () {
+    final theme = buildAnchorDemoTheme(cellAnchor: TooltipAnchor.pointer);
+    expect(theme.tooltipTheme.anchor, TooltipAnchor.pointer);
+  });
+
+  test('the header follows the cells until told otherwise', () {
+    // Null is the point: it selects the package's documented fallback to
+    // tooltipTheme, so the demo walks that path unless a visitor steps off it.
+    // Handing the header a theme eagerly would leave the fallback unexercised
+    // while the screen still looked right.
+    expect(buildAnchorDemoTheme().headerTooltipTheme, isNull);
+  });
+
+  test('a chosen header anchor gives the header a theme of its own', () {
+    final theme = buildAnchorDemoTheme(
+      headerAnchor: HeaderAnchorChoice.pointer,
+    );
+    expect(theme.headerTooltipTheme?.anchor, TooltipAnchor.pointer);
+    expect(theme.tooltipTheme.anchor, TooltipAnchor.child,
+        reason: 'the cell anchor is untouched by the header one');
+  });
+
+  test('the header can walk back to following the cells', () {
+    final theme = buildAnchorDemoTheme(
+      cellAnchor: TooltipAnchor.pointer,
+      headerAnchor: HeaderAnchorChoice.followCells,
+    );
+    expect(theme.headerTooltipTheme, isNull);
+    expect(theme.tooltipTheme.anchor, TooltipAnchor.pointer);
+  });
+}

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1,5 +1,6 @@
 import 'package:example/main.dart';
 import 'package:example/pages/playground/models/employee.dart';
+import 'package:example/pages/tooltip_anchor/tooltip_anchor_page.dart';
 import 'package:flutter_table_plus/flutter_table_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -21,6 +22,17 @@ void main() {
         reason: 'the home lists demos; it does not host one');
   });
 
+  testWidgets('the home offers the tooltip anchor demo', (tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Tooltip anchors'), findsOneWidget);
+    expect(
+        find.text(
+            'Where a tooltip sits: beside the cell, or beside the cursor'),
+        findsOneWidget);
+  });
+
   testWidgets('opening the playground renders its table', (tester) async {
     await tester.pumpWidget(const MyApp());
     await tester.pumpAndSettle();
@@ -30,5 +42,16 @@ void main() {
 
     expect(find.byType(FlutterTablePlus<Employee>), findsOneWidget);
     expect(find.text('Name'), findsOneWidget, reason: 'a header cell painted');
+  });
+
+  testWidgets('opening the tooltip anchor demo renders its table',
+      (tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Tooltip anchors'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FlutterTablePlus<TooltipAnchorRow>), findsOneWidget);
   });
 }


### PR DESCRIPTION
Closes #61

Anchoring is obvious in one hover and opaque in prose. Until now the only place to try it was the playground, behind five sections of unrelated controls and a hundred rows of data — which is what prompted this whole strand of work.

The page holds one truncated value, one truncated heading, a row card, and two controls.

## What the page has to get right

**Truncation is not decoration.** A text tooltip's hover target is the `Text` itself, so with a short value the child's centre and the cursor sit a few pixels apart and both anchors look identical. The column is narrow and the value is long so the two are far enough apart to tell apart.

**Leaving the header alone must exercise the fallback.** `follow cells` leaves `headerTooltipTheme` null, so the demo walks the package's documented fallback to `tooltipTheme` on every ordinary visit rather than only when someone goes looking for it. A test holds that line — filling the header's theme eagerly would leave the fallback unexercised while the screen still looked right.

**The page says what the controls cannot show.** The row card ignores both anchors and always sits beside the pointer, because a row is as wide as the table's content and anchoring to it would aim at a point that can scroll off screen. A demo that lets you move two anchors while a third thing refuses to move must say why, or it reads as a bug. It also says that `alignment` changes meaning under `pointer` — against a point there are no target edges to line up with, so it picks one of the tooltip's own. Both notes sit where the controls are.

## What the tests do and do not cover

The demo's only logic is turning two choices into a `TablePlusTheme`, and that is what the five unit tests cover, including the null-header fallback and the walk back to it.

Whether a tooltip then lands beside the cursor belongs to the package, and `test/tooltip_anchor_test.dart` pins it with five behavioural tests already. Repeating that here would test `just_tooltip` twice and would drag the demo's fixtures into the font and screen-margin traps that made those package tests fiddly.

## Two smaller decisions

The header choice is a three-value enum of the demo's own. The playground has an identical one, but a second occurrence is not yet a pattern, and each belongs to the page whose controls it describes.

With two entries on the home, their shape is finally visible, so the `ListTile` is extracted into a `_DemoTile`. That is exactly what #58 deferred, and the existing tests caught nothing changing.

## Verification

`cd example && flutter test` passes (18 tests), the package's 378 are untouched and green, `flutter analyze` is clean in both, `dart format` leaves both unchanged. No overflow under the widget-test font. Each new test was checked to fail without its production change. The page itself was driven and confirmed on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)