### PR TITLE
Let the settings panel's labels yield instead of bursting their row

### DIFF
--- a/example/lib/pages/playground/widgets/settings_controls.dart
+++ b/example/lib/pages/playground/widgets/settings_controls.dart
@@ -93,14 +93,19 @@ Widget buildSwitchTile({
     padding: const EdgeInsets.symmetric(vertical: 4),
     child: Row(
       children: [
-        Text(
-          label,
-          style: const TextStyle(
-            fontSize: 14,
-            fontWeight: FontWeight.w500,
+        // The panel is a fixed 380 wide. The label has to yield the space the
+        // control needs, not push it off the edge — a wider text scale, or a
+        // longer translation, will ask it to.
+        Expanded(
+          child: Text(
+            label,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+            ),
           ),
         ),
-        const Spacer(),
         Switch(
           value: value,
           onChanged: onChanged,
@@ -120,14 +125,16 @@ Widget buildDropdownRow<T>({
 }) {
   return Row(
     children: [
-      Text(
-        label,
-        style: const TextStyle(
-          fontSize: 14,
-          fontWeight: FontWeight.w500,
+      Expanded(
+        child: Text(
+          label,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+          ),
         ),
       ),
-      const Spacer(),
       DropdownButton<T>(
         value: value,
         onChanged: (T? newValue) {

--- a/example/test/settings_panel_test.dart
+++ b/example/test/settings_panel_test.dart
@@ -43,22 +43,17 @@ Widget _panel({PlaygroundSettings settings = const PlaygroundSettings()}) {
   return MaterialApp(
     home: Scaffold(
       // The test font draws every glyph as a square of the font size, so the
-      // panel's labels measure far wider here than on screen and burst a dozen
-      // of its fixed-width rows. This test counts controls; it does not judge
-      // layout. Shrink the text until the labels fit and the counting can
-      // proceed. (Those rows are fragile under a real accessibility text scale
-      // too — a separate concern from moving them between files.)
-      body: MediaQuery(
-        data: const MediaQueryData(textScaler: TextScaler.linear(0.5)),
-        child: SettingsPanel(
-          settings: settings,
-          performanceMetrics: PerformanceMetrics(
-            rowCount: 0,
-            lastUpdate: DateTime.fromMillisecondsSinceEpoch(0),
-          ),
-          onSettingsChanged: (_) {},
-          onGenerateData: () {},
+      // panel's labels measure far wider here than on screen. Nothing is
+      // shrunk to compensate: a control row that cannot hold its own label is
+      // a bug, and one a real accessibility text scale would find.
+      body: SettingsPanel(
+        settings: settings,
+        performanceMetrics: PerformanceMetrics(
+          rowCount: 0,
+          lastUpdate: DateTime.fromMillisecondsSinceEpoch(0),
         ),
+        onSettingsChanged: (_) {},
+        onGenerateData: () {},
       ),
     ),
   );


### PR DESCRIPTION
Closes #65

The playground's settings panel is a fixed 380 wide, and two of the helpers that build its controls laid their `Row` out as `[Text, Spacer, control]`. The `Spacer` eats whatever space is left, so a label with nowhere to shrink pushes the control off the edge instead.

Nobody has seen it, because at the default text scale the labels fit. Under the widget-test font, whose glyphs are squares of the font size, the panel produced **34 overflows traced to exactly two source lines** — the switch tile and the dropdown row. A real accessibility text scale, or a wordier translation, reaches the same place.

The labels are now `Expanded` and ellipsize. `Spacer` and `Expanded` cannot share a `Row`: one takes the leftover space, the other shares it, and sharing is what a label needs.

## Twenty-five switches and twelve dropdowns, two edits

This is the same bug fixed in #55 for the performance monitor's title, in this same panel. It outlived that fix because the fault lives in a helper rather than in a widget: two definitions, thirty-seven call sites. Aggregating the failures by source line is what turned "about a dozen rows overflow" into "these two lines do".

## The red was deleting a workaround

The characterisation test written for #59 shrank the text to `TextScaler.linear(0.5)` so it could count controls without drowning in overflow errors, and #65 recorded that removing the shrink would be the cleanest proof this was done.

That shrink is gone. The test passing without it is the proof, and the reason it stays: a control row that cannot hold its own label now fails the suite. Restoring the old `Row` reproduces all 34 overflows.

## Verification

`cd example && flutter test` passes (18 tests) with zero overflows, the package's 378 are untouched and green, `flutter analyze` is clean in both, `dart format` leaves both unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)