### PR TITLE
fix(tooltip): adopt just_tooltip 0.4.2 and correct the anchor rationale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 ## 2.15.0
 
+*   **BREAKING**: minimum Flutter is now `3.13.0` (Dart `3.1.0`), up from `3.10.0`. `just_tooltip` 0.4.2 walks `RenderObject.parent`, which was `AbstractNode?` — a type with no `describeApproximatePaintClip` — before Flutter 3.13. The `just_tooltip: ^0.4.0` constraint already resolved 0.4.2, so the old floor had quietly become a promise this package could not keep; raising it is the honest fix, not the cause
+*   **DEPS**: `just_tooltip: ^0.4.2`. Upstream now anchors `TooltipAnchor.child` to the *visible* part of the child, re-aims a shown tooltip when its child moves, and hides it once the child is clipped out of sight. Cell and row tooltip behaviour here is unchanged; all 378 tests pass unmodified
+
 *   **FEAT**: `TablePlusTooltipTheme.anchor` — position a tooltip beside the cursor instead of beside the widget it wraps
-    *   `TooltipAnchor.child` (the default) anchors to the hovered widget's rect. That is wrong whenever the widget is far wider than the neighbourhood the user is pointing at: a cell whose text is long enough to ellipsize fills its whole column, so its tooltip appeared at the column's centre, possibly a screen away from the cursor. `TooltipAnchor.pointer` keeps the same hover region and anchors at the cursor
+    *   `TooltipAnchor.child` (the default) anchors to the visible part of the hovered widget's rect. That is wrong whenever the widget is far wider than the neighbourhood the user is pointing at: a cell in a column wider than the viewport gets a tooltip at the centre of whatever slice is on screen, wherever the cursor may be. `TooltipAnchor.pointer` keeps the same hover region and anchors at the cursor
     *   Against a point there are no target edges to align to, so under `TooltipAnchor.pointer` the `alignment` field selects which of the tooltip's *own* edges lands on the cursor
     *   `TooltipAnchor` is now re-exported, so you no longer need `just_tooltip` in your own `pubspec.yaml` to name it
-    *   Row tooltips built by `rowTooltipBuilder` always anchored at the pointer and still do; they ignore this field. A row is as wide as the table's content, so anchoring to the row would aim at a point that scrolls off screen
+    *   Row tooltips built by `rowTooltipBuilder` always anchored at the pointer and still do; they ignore this field. A row is as wide as the table's content, so a child anchor would aim at the centre of whatever slice of the row is on screen — visible, but unrelated to where along the row the cursor is
 *   **FEAT**: `TablePlusTheme.headerTooltipTheme` — style header tooltips apart from cell tooltips
     *   Header and cell tooltips were styled by one `tooltipTheme`, so tooltip *behavior* was separable (`headerTooltipBehavior` vs `tooltipBehavior`) while tooltip *style* was not. With `anchor` exposed, that asymmetry bit: anchoring a header at the pointer dragged every cell along with it
     *   Nullable, and falls back to `tooltipTheme` when unset — the same shape as `rowTooltipTheme`. Leave it null and nothing changes

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A highly customizable, type-safe Flutter table widget with synchronized scrollin
 
 ```yaml
 dependencies:
-  flutter_table_plus: ^2.14.0
+  flutter_table_plus: ^2.15.0
 ```
 
 ```bash

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -410,8 +410,9 @@ Two things to know:
   ```
 
 Row tooltips built by `rowTooltipBuilder` always anchor at the pointer and
-ignore this field. A row is as wide as the table's content, so anchoring to the
-row would aim at a point that scrolls off screen.
+ignore this field. A row is as wide as the table's content, so a child anchor
+would aim at the centre of whatever slice of the row is on screen — visible, but
+unrelated to where along the row you are pointing.
 
 ---
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -116,7 +116,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.15.0"
+    version: "2.16.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -150,10 +150,10 @@ packages:
     dependency: transitive
     description:
       name: just_tooltip
-      sha256: "588ca22fb723e33f31f9ab61f125b51c507959b0e86d42503143395c585991f7"
+      sha256: eb0093e47d2a2f95ae81a3f309544905e97cd99ab4519bedfa8101fc275b7f43
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.4.2"
   leak_tracker:
     dependency: transitive
     description:

--- a/lib/src/models/theme/tooltip_theme.dart
+++ b/lib/src/models/theme/tooltip_theme.dart
@@ -106,11 +106,11 @@ class TablePlusTooltipTheme {
 
   /// What the tooltip is positioned against.
   ///
-  /// [TooltipAnchor.child] (the default) places the tooltip beside the rect of
-  /// the widget it wraps. [TooltipAnchor.pointer] leaves the hover region alone
-  /// and places the tooltip beside the cursor instead — useful when the hovered
-  /// widget is much wider than the neighbourhood the user is pointing at, such
-  /// as a long ellipsized cell.
+  /// [TooltipAnchor.child] (the default) places the tooltip beside the visible
+  /// part of the widget it wraps. [TooltipAnchor.pointer] leaves the hover
+  /// region alone and places the tooltip beside the cursor instead — useful
+  /// when the hovered widget is much wider than the neighbourhood the user is
+  /// pointing at, such as a cell in a column wider than the viewport.
   ///
   /// Cell tooltips read this from `TablePlusTheme.tooltipTheme` and header
   /// tooltips from `TablePlusTheme.headerTooltipTheme`, which falls back to the
@@ -118,8 +118,8 @@ class TablePlusTooltipTheme {
   ///
   /// Row tooltips built by `rowTooltipBuilder` always use
   /// [TooltipAnchor.pointer] and ignore this field: a row is as wide as the
-  /// table's content, so anchoring to it would aim at a point that may be off
-  /// screen.
+  /// table's content, so a child anchor would aim at the centre of the visible
+  /// slice — the viewport's centre, not the cell under the cursor.
   ///
   /// See also [alignment], whose meaning depends on this field.
   final TooltipAnchor anchor;

--- a/lib/src/widgets/flutter_tooltip_plus.dart
+++ b/lib/src/widgets/flutter_tooltip_plus.dart
@@ -42,7 +42,9 @@ class FlutterTooltipPlus extends StatelessWidget {
   /// Leave it null and the theme decides, which is what cell and header
   /// tooltips want. Pass [TooltipAnchor.pointer] to anchor beside the cursor no
   /// matter what the theme says — the row tooltip must, because [child] is then
-  /// as wide as the table's content and its centre can be off screen.
+  /// as wide as the table's content, and a child anchor would aim at the
+  /// centre of whatever slice of it happens to be on screen: visible, but
+  /// nowhere near the cell the user is pointing at.
   final TooltipAnchor? anchor;
 
   /// The text to display in the tooltip.

--- a/lib/src/widgets/table_body.dart
+++ b/lib/src/widgets/table_body.dart
@@ -400,8 +400,9 @@ class TablePlusBodyState<T> extends State<TablePlusBody<T>>
         final row = _buildRowWidget(actualIndex, index);
 
         // The row is the hover region; the pointer is the anchor. A row's
-        // RenderBox is `contentWidth` wide, so anchoring to it would aim at its
-        // centre — off screen once the table scrolls horizontally.
+        // RenderBox is `contentWidth` wide, so anchoring to it would aim at the
+        // centre of the visible slice — the viewport's centre, wherever the
+        // cursor happens to be along the row.
         //
         // A merged row stands for several data rows, so there is no single
         // `rowData` to hand the builder; it gets no tooltip.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,15 +10,20 @@ topics:
   - grid
   - datagrid
 
+# Raised from Dart 3.0.0 / Flutter 3.10.0 by just_tooltip 0.4.2, whose ancestor
+# clip walk reads `RenderObject.parent`. That was `AbstractNode?` — a type with
+# no `describeApproximatePaintClip` — until Flutter 3.13. Our `^0.4.0` already
+# resolved 0.4.2, so the old floor had quietly become a promise we could not
+# keep; raising it is the honest fix, not the cause.
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:
     sdk: flutter
   flutter_checkbox: ^0.2.1
-  just_tooltip: ^0.4.0
+  just_tooltip: ^0.4.2
 
 dev_dependencies:
   flutter_test:

--- a/test/hover_rebuild_test.dart
+++ b/test/hover_rebuild_test.dart
@@ -56,7 +56,8 @@ void main() {
     await tester.pump();
 
     expect(cellBuilds, before,
-        reason: 'rows must not rebuild on hover when there are no hover buttons');
+        reason:
+            'rows must not rebuild on hover when there are no hover buttons');
   });
 
   testWidgets('with hover buttons: hovering a row reveals its hover button',

--- a/test/row_tooltip_test.dart
+++ b/test/row_tooltip_test.dart
@@ -93,9 +93,9 @@ void main() {
 
   testWidgets('the card anchors at the pointer, not the row rect',
       (tester) async {
-    // Three 600px columns: the row is 1800 wide inside an 800px viewport, so
-    // the row's centre is off screen. Anchoring to the row would put the card
-    // there (and screenMargin would silently clamp it back).
+    // Three 600px columns: the row is 1800 wide inside an 800px viewport. A
+    // child anchor would aim at the centre of the row's *visible* slice — the
+    // viewport's centre — which is on screen but unrelated to the cursor.
     await tester.pumpWidget(_table(columns: {
       'name': _col('name', width: 600),
       'note': _col('note', width: 600),
@@ -119,8 +119,9 @@ void main() {
       (tester) async {
     // tooltipTheme.anchor governs cells, and rowTooltipTheme falls back to it
     // when unset — so a caller who anchors their cell tooltips to the child
-    // must not thereby drag the row card onto the row's rect, whose centre
-    // (x≈900) is off screen.
+    // must not thereby drag the row card onto the row's visible centre, which
+    // sits wherever the table happens to be scrolled rather than at the
+    // cursor.
     await tester.pumpWidget(_table(
       columns: {
         'name': _col('name', width: 600),


### PR DESCRIPTION
## No behaviour changes

`just_tooltip` 0.4.2 targets the visible part of a clipped child, so `TooltipAnchor.child` no longer aims at a centre nobody can see.

This package never hit that defect. Row tooltips already force `TooltipAnchor.pointer` (`table_body.dart`), and cell tooltips wrap a `Text` laid out inside its column, so their rect never exceeds the ancestor that clips it. Verified: all **378 tests pass unmodified** against 0.4.2 via a temporary `pubspec_overrides.yaml`. Nothing broke, and nothing needed to.

## What was wrong: the reason, not the code

Six places recorded the same rationale:

> anchoring to the row would aim at a point that scrolls **off screen**

True against `just_tooltip` 0.4.1 and earlier. **False now.** A child anchor lands on the centre of the row's *visible slice* — the viewport's centre. On screen, but unrelated to where along the row the cursor is.

The conclusion (`pointer` for row tooltips) is unchanged. Only the reason is: it went from *avoiding a bug* to *the cursor is genuinely the right anchor*. Left stale, it invites the next reader to conclude "the bug is fixed, so we can drop `pointer`."

Corrected in `tooltip_theme.dart` (×2), `flutter_tooltip_plus.dart`, `table_body.dart`, `docs/THEMING.md`, and two comments in `test/row_tooltip_test.dart`. One of those test comments — *"screenMargin would silently clamp it back"* — was wrong twice over: no clamp fires, and the tooltip never leaves the view.

## The Flutter floor was already broken

`just_tooltip: ^0.4.0` resolves to `0.4.2` under caret rules — `pubspec.lock` confirms it does today. `0.4.2` walks `RenderObject.parent`, which was `AbstractNode?` (no `describeApproximatePaintClip`) before Flutter 3.13.

So `flutter: ">=3.10.0"` had **quietly become a promise this package could not keep**. Raising it to `3.13.0` / Dart `3.1.0` is the honest fix, not the cause. Constraint pinned to `^0.4.2` to say so explicitly.

## Why 2.15.0 and not 2.16.0

`flutter pub publish --dry-run` reported *"The previous version is 2.14.0"* — **2.15.0 is unpublished**. So this folds into that entry instead of stacking a version on top of one pub.dev has never seen.

That also made its changelog editable: the 2.15.0 entry carried the same off-screen rationale, corrected here in place. Had it shipped, pub.dev's snapshot would have frozen it and the fix would have had to live in 2.16.0's notes instead.

`flutter test` 378 passing, `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)