### PR TITLE
Lift the playground's columns out of its page

### DIFF
--- a/example/lib/pages/playground/playground_columns.dart
+++ b/example/lib/pages/playground/playground_columns.dart
@@ -1,0 +1,210 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_table_plus/flutter_table_plus.dart';
+
+import 'models/employee.dart';
+import 'models/playground_settings.dart';
+import 'playground_format.dart';
+
+/// The columns the playground builds from its [PlaygroundSettings].
+///
+/// Free of `BuildContext` and of widget state: the `context`s below are handed
+/// in by the cell builders the table calls, not the page's own.
+Map<String, TablePlusColumn<Employee>> buildPlaygroundColumns(
+  PlaygroundSettings settings,
+) {
+  final builder = TableColumnsBuilder<Employee>();
+
+  final cellTooltip = settings.tooltipBehavior;
+  final headerTooltip = settings.headerTooltipBehavior;
+  final minW = settings.columnMinWidth;
+
+  builder.addColumn(
+    'avatar',
+    TablePlusColumn<Employee>(
+      key: 'avatar',
+      label: '👤',
+      order: 0,
+      valueAccessor: (row) => row.avatar,
+      width: 60,
+      minWidth: minW,
+      maxWidth: 80,
+      sortable: false,
+      tooltipBehavior: cellTooltip,
+      headerTooltipBehavior: headerTooltip,
+    ),
+  );
+
+  builder.addColumn(
+    'name',
+    TablePlusColumn<Employee>(
+      key: 'name',
+      label: 'Name',
+      order: 0,
+      valueAccessor: (row) => row.name,
+      width: 180,
+      minWidth: minW,
+      sortable: settings.sortingEnabled,
+      tooltipBehavior: cellTooltip,
+      headerTooltipBehavior: headerTooltip,
+      tooltipBuilder: settings.showTooltipBuilder
+          ? (context, employee) => Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    employee.name,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 14,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text('${employee.position} - ${employee.department}'),
+                  Text(
+                    '\$${formatPlaygroundNumber(employee.salary)}',
+                    style: TextStyle(color: Colors.green.shade300),
+                  ),
+                ],
+              )
+          : null,
+    ),
+  );
+
+  builder.addColumn(
+    'position',
+    TablePlusColumn<Employee>(
+      key: 'position',
+      label: 'Position',
+      order: 0,
+      valueAccessor: (row) => row.position,
+      width: 200,
+      minWidth: minW,
+      sortable: settings.sortingEnabled,
+      editable: settings.editingEnabled,
+      tooltipBehavior: cellTooltip,
+      headerTooltipBehavior: headerTooltip,
+    ),
+  );
+
+  builder.addColumn(
+    'department',
+    TablePlusColumn<Employee>(
+      key: 'department',
+      label: 'Department',
+      order: 0,
+      valueAccessor: (row) => row.department,
+      width: 150,
+      minWidth: minW,
+      sortable: settings.sortingEnabled,
+      editable: settings.editingEnabled,
+      tooltipBehavior: cellTooltip,
+      headerTooltipBehavior: headerTooltip,
+    ),
+  );
+
+  builder.addColumn(
+    'salary',
+    TablePlusColumn<Employee>(
+      key: 'salary',
+      label: 'Salary',
+      order: 0,
+      valueAccessor: (row) => row.salary,
+      width: 120,
+      minWidth: minW,
+      maxWidth: 150,
+      sortable: settings.sortingEnabled,
+      editable: settings.editingEnabled,
+      tooltipBehavior: cellTooltip,
+      headerTooltipBehavior: headerTooltip,
+      statefulCellBuilder: (context, employee, isSelected, isDim) {
+        return Center(
+          child: Text(
+            '\$${formatPlaygroundNumber(employee.salary)}',
+            style: TextStyle(
+              fontWeight: FontWeight.w600,
+              color: isSelected
+                  ? Colors.white
+                  : isDim
+                      ? Colors.green.shade300
+                      : Colors.green.shade700,
+            ),
+          ),
+        );
+      },
+    ),
+  );
+
+  builder.addColumn(
+    'performance',
+    TablePlusColumn<Employee>(
+      key: 'performance',
+      label: 'Performance',
+      order: 0,
+      valueAccessor: (row) => row.performance,
+      width: 130,
+      minWidth: minW,
+      maxWidth: 160,
+      sortable: settings.sortingEnabled,
+      tooltipBehavior: cellTooltip,
+      headerTooltipBehavior: headerTooltip,
+      statefulCellBuilder: (context, employee, isSelected, isDim) {
+        return Center(
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: isDim
+                  ? performanceColor(employee.performance)
+                      .withValues(alpha: 0.5)
+                  : performanceColor(employee.performance),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              '${(employee.performance * 100).toStringAsFixed(0)}%',
+              style: const TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+          ),
+        );
+      },
+    ),
+  );
+
+  builder.addColumn(
+    'email',
+    TablePlusColumn<Employee>(
+      key: 'email',
+      label: 'Email',
+      order: 0,
+      valueAccessor: (row) => row.email,
+      width: 220,
+      minWidth: minW,
+      sortable: settings.sortingEnabled,
+      tooltipBehavior: cellTooltip,
+      headerTooltipBehavior: headerTooltip,
+      tooltipFormatter: settings.showTooltipFormatter
+          ? (employee) => 'Send to: ${employee.email}'
+          : null,
+    ),
+  );
+
+  builder.addColumn(
+    'phone',
+    TablePlusColumn<Employee>(
+      key: 'phone',
+      label: 'Phone',
+      order: 0,
+      valueAccessor: (row) => row.phone,
+      width: 130,
+      minWidth: minW,
+      maxWidth: 160,
+      sortable: settings.sortingEnabled,
+      tooltipBehavior: cellTooltip,
+      headerTooltipBehavior: headerTooltip,
+    ),
+  );
+
+  return builder.build();
+}

--- a/example/lib/pages/playground/playground_format.dart
+++ b/example/lib/pages/playground/playground_format.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+/// Formatting the playground shares between its columns and its own chrome.
+
+String formatPlaygroundNumber(int number) {
+  if (number >= 1000000) {
+    return '${(number / 1000000).toStringAsFixed(1)}M';
+  } else if (number >= 1000) {
+    return '${(number / 1000).toStringAsFixed(1)}K';
+  }
+  return number.toString();
+}
+
+Color performanceColor(double performance) {
+  if (performance >= 0.9) {
+    return Colors.green.shade600;
+  } else if (performance >= 0.75) {
+    return Colors.blue.shade600;
+  } else if (performance >= 0.6) {
+    return Colors.orange.shade600;
+  } else {
+    return Colors.red.shade600;
+  }
+}

--- a/example/lib/pages/playground/playground_page.dart
+++ b/example/lib/pages/playground/playground_page.dart
@@ -7,6 +7,8 @@ import 'package:google_fonts/google_fonts.dart';
 
 import 'models/employee.dart';
 import 'models/playground_settings.dart';
+import 'playground_columns.dart';
+import 'playground_format.dart';
 import 'utils/random_data_generator.dart';
 import 'widgets/performance_monitor.dart';
 import 'widgets/settings_panel.dart';
@@ -57,208 +59,11 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
   @override
   void initState() {
     super.initState();
-    _initializeColumns();
+    _columns = buildPlaygroundColumns(_settings);
     _generateData();
   }
 
   /// Initialize table columns
-  void _initializeColumns() {
-    final builder = TableColumnsBuilder<Employee>();
-
-    final cellTooltip = _settings.tooltipBehavior;
-    final headerTooltip = _settings.headerTooltipBehavior;
-    final minW = _settings.columnMinWidth;
-
-    builder.addColumn(
-      'avatar',
-      TablePlusColumn<Employee>(
-        key: 'avatar',
-        label: '👤',
-        order: 0,
-        valueAccessor: (row) => row.avatar,
-        width: 60,
-        minWidth: minW,
-        maxWidth: 80,
-        sortable: false,
-        tooltipBehavior: cellTooltip,
-        headerTooltipBehavior: headerTooltip,
-      ),
-    );
-
-    builder.addColumn(
-      'name',
-      TablePlusColumn<Employee>(
-        key: 'name',
-        label: 'Name',
-        order: 0,
-        valueAccessor: (row) => row.name,
-        width: 180,
-        minWidth: minW,
-        sortable: _settings.sortingEnabled,
-        tooltipBehavior: cellTooltip,
-        headerTooltipBehavior: headerTooltip,
-        tooltipBuilder: _settings.showTooltipBuilder
-            ? (context, employee) => Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      employee.name,
-                      style: const TextStyle(
-                        fontWeight: FontWeight.bold,
-                        fontSize: 14,
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    Text('${employee.position} - ${employee.department}'),
-                    Text(
-                      '\$${_formatNumber(employee.salary)}',
-                      style: TextStyle(color: Colors.green.shade300),
-                    ),
-                  ],
-                )
-            : null,
-      ),
-    );
-
-    builder.addColumn(
-      'position',
-      TablePlusColumn<Employee>(
-        key: 'position',
-        label: 'Position',
-        order: 0,
-        valueAccessor: (row) => row.position,
-        width: 200,
-        minWidth: minW,
-        sortable: _settings.sortingEnabled,
-        editable: _settings.editingEnabled,
-        tooltipBehavior: cellTooltip,
-        headerTooltipBehavior: headerTooltip,
-      ),
-    );
-
-    builder.addColumn(
-      'department',
-      TablePlusColumn<Employee>(
-        key: 'department',
-        label: 'Department',
-        order: 0,
-        valueAccessor: (row) => row.department,
-        width: 150,
-        minWidth: minW,
-        sortable: _settings.sortingEnabled,
-        editable: _settings.editingEnabled,
-        tooltipBehavior: cellTooltip,
-        headerTooltipBehavior: headerTooltip,
-      ),
-    );
-
-    builder.addColumn(
-      'salary',
-      TablePlusColumn<Employee>(
-        key: 'salary',
-        label: 'Salary',
-        order: 0,
-        valueAccessor: (row) => row.salary,
-        width: 120,
-        minWidth: minW,
-        maxWidth: 150,
-        sortable: _settings.sortingEnabled,
-        editable: _settings.editingEnabled,
-        tooltipBehavior: cellTooltip,
-        headerTooltipBehavior: headerTooltip,
-        statefulCellBuilder: (context, employee, isSelected, isDim) {
-          return Center(
-            child: Text(
-              '\$${_formatNumber(employee.salary)}',
-              style: TextStyle(
-                fontWeight: FontWeight.w600,
-                color: isSelected
-                    ? Colors.white
-                    : isDim
-                        ? Colors.green.shade300
-                        : Colors.green.shade700,
-              ),
-            ),
-          );
-        },
-      ),
-    );
-
-    builder.addColumn(
-      'performance',
-      TablePlusColumn<Employee>(
-        key: 'performance',
-        label: 'Performance',
-        order: 0,
-        valueAccessor: (row) => row.performance,
-        width: 130,
-        minWidth: minW,
-        maxWidth: 160,
-        sortable: _settings.sortingEnabled,
-        tooltipBehavior: cellTooltip,
-        headerTooltipBehavior: headerTooltip,
-        statefulCellBuilder: (context, employee, isSelected, isDim) {
-          return Center(
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              decoration: BoxDecoration(
-                color: isDim
-                    ? _getPerformanceColor(employee.performance)
-                        .withValues(alpha: 0.5)
-                    : _getPerformanceColor(employee.performance),
-                borderRadius: BorderRadius.circular(4),
-              ),
-              child: Text(
-                '${(employee.performance * 100).toStringAsFixed(0)}%',
-                style: const TextStyle(
-                  fontSize: 12,
-                  fontWeight: FontWeight.bold,
-                  color: Colors.white,
-                ),
-              ),
-            ),
-          );
-        },
-      ),
-    );
-
-    builder.addColumn(
-      'email',
-      TablePlusColumn<Employee>(
-        key: 'email',
-        label: 'Email',
-        order: 0,
-        valueAccessor: (row) => row.email,
-        width: 220,
-        minWidth: minW,
-        sortable: _settings.sortingEnabled,
-        tooltipBehavior: cellTooltip,
-        headerTooltipBehavior: headerTooltip,
-        tooltipFormatter: _settings.showTooltipFormatter
-            ? (employee) => 'Send to: ${employee.email}'
-            : null,
-      ),
-    );
-
-    builder.addColumn(
-      'phone',
-      TablePlusColumn<Employee>(
-        key: 'phone',
-        label: 'Phone',
-        order: 0,
-        valueAccessor: (row) => row.phone,
-        width: 130,
-        minWidth: minW,
-        maxWidth: 160,
-        sortable: _settings.sortingEnabled,
-        tooltipBehavior: cellTooltip,
-        headerTooltipBehavior: headerTooltip,
-      ),
-    );
-
-    _columns = builder.build();
-  }
 
   /// The row tooltip's card. It draws its own surface, which is why the
   /// playground gives `rowTooltipTheme` a transparent, unpadded one.
@@ -357,7 +162,7 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
           newSettings.columnMinWidth != oldSettings.columnMinWidth;
 
       if (needsColumnRebuild) {
-        _initializeColumns();
+        _columns = buildPlaygroundColumns(_settings);
       }
 
       // Clear selection when selection is disabled
@@ -581,7 +386,7 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
       'Name': employee.name,
       'Position': employee.position,
       'Department': employee.department,
-      'Salary': '\$${_formatNumber(employee.salary)}',
+      'Salary': '\$${formatPlaygroundNumber(employee.salary)}',
       'Performance': '${(employee.performance * 100).toStringAsFixed(0)}%',
       'Email': employee.email,
       'Phone': employee.phone,
@@ -779,7 +584,7 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
                     borderRadius: BorderRadius.circular(4),
                   ),
                   child: Text(
-                    '${_formatNumber(_data.length)} rows',
+                    '${formatPlaygroundNumber(_data.length)} rows',
                     style: const TextStyle(
                       fontSize: 14,
                       fontWeight: FontWeight.w600,
@@ -964,27 +769,6 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
         theme: buildPlaygroundTheme(_settings),
       ),
     );
-  }
-
-  Color _getPerformanceColor(double performance) {
-    if (performance >= 0.9) {
-      return Colors.green.shade600;
-    } else if (performance >= 0.75) {
-      return Colors.blue.shade600;
-    } else if (performance >= 0.6) {
-      return Colors.orange.shade600;
-    } else {
-      return Colors.red.shade600;
-    }
-  }
-
-  String _formatNumber(int number) {
-    if (number >= 1000000) {
-      return '${(number / 1000000).toStringAsFixed(1)}M';
-    } else if (number >= 1000) {
-      return '${(number / 1000).toStringAsFixed(1)}K';
-    }
-    return number.toString();
   }
 }
 

--- a/example/test/playground_columns_test.dart
+++ b/example/test/playground_columns_test.dart
@@ -1,0 +1,39 @@
+import 'package:example/pages/playground/models/employee.dart';
+import 'package:example/pages/playground/playground_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_table_plus/flutter_table_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// A characterisation test, written before the column definitions are lifted out
+// of the page. Nothing else in the example would notice a column going missing:
+// the smoke test looks for one header, and the theme test never sees a column.
+
+const _headers = [
+  '\u{1F464}',
+  'Name',
+  'Position',
+  'Department',
+  'Salary',
+  'Performance',
+  'Email',
+  'Phone',
+];
+
+void main() {
+  testWidgets('the playground renders every column it defines', (tester) async {
+    // The table is wider than a default test surface. Headers still build —
+    // the header row is a plain scroll view, not a lazy list — but give it room
+    // so nothing has to be scrolled into existence.
+    tester.view.physicalSize = const Size(2400, 1200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(const MaterialApp(home: PlaygroundPage()));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FlutterTablePlus<Employee>), findsOneWidget);
+    for (final header in _headers) {
+      expect(find.text(header), findsOneWidget, reason: header);
+    }
+  });
+}


### PR DESCRIPTION
Closes #60

`_initializeColumns` read `_settings` and assigned `_columns`, and nothing else. The three `BuildContext`s inside it belong to the cell builders the table calls, not to the page. It was a method only because of where it was written — exactly what was true of the theme builder before #54 hoisted it.

It is now `buildPlaygroundColumns(PlaygroundSettings)` in its own file. The page loses 215 lines, 1,156 down to 941.

## A pure move needs a net

There is no red to write, and nothing in the example's suite would have noticed a column disappearing: the smoke test looks for one header, the theme test never sees a column. The first commit pins the eight the page defines today. It passes unchanged after the move, which is the only evidence the move changed nothing.

## Two helpers had to come along

The columns call `_formatNumber` and `_getPerformanceColor`, both private methods of the page's state and both pure — they take an argument and return a value. A dependency scan that looked only for `_settings`, `_columns` and `context` missed them, and the compiler said so the moment the columns moved.

The page calls the number formatter too, so leaving it behind would have made the columns file import the page. Both helpers sit in a small shared file instead, and the dependency runs one way: page → columns → formatting.

## Still in the page

`buildPlaygroundTheme` remains there, top-level but not yet in a file of its own. Same argument applies to it; out of scope here.

## Verification

`cd example && flutter test` passes (19 tests), the package's 378 are untouched and green, `flutter analyze` is clean in both, `dart format` leaves both unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)