### PR TITLE
Search the settings panel

### DIFF
--- a/example/lib/pages/playground/widgets/sections/data_settings_section.dart
+++ b/example/lib/pages/playground/widgets/sections/data_settings_section.dart
@@ -60,6 +60,7 @@ class DataSettingsSection extends StatelessWidget {
 
         // Logarithmic slider (5 to 100,000)
         buildLogSlider(
+          label: 'Row Count',
           value: settings.rowCount.toDouble(),
           min: 5,
           max: 100000,

--- a/example/lib/pages/playground/widgets/sections/data_settings_section.dart
+++ b/example/lib/pages/playground/widgets/sections/data_settings_section.dart
@@ -6,6 +6,7 @@ import '../settings_controls.dart';
 class DataSettingsSection extends StatelessWidget {
   final PlaygroundSettings settings;
   final ValueChanged<PlaygroundSettings> onSettingsChanged;
+  final String query;
   final VoidCallback onGenerateData;
   final bool isGenerating;
 
@@ -13,6 +14,7 @@ class DataSettingsSection extends StatelessWidget {
     super.key,
     required this.settings,
     required this.onSettingsChanged,
+    this.query = '',
     required this.onGenerateData,
     this.isGenerating = false,
   });
@@ -20,6 +22,7 @@ class DataSettingsSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return buildSection(
+      query: query,
       title: 'Data Settings',
       icon: Icons.data_array,
       color: Colors.green.shade700,

--- a/example/lib/pages/playground/widgets/sections/feature_toggles_section.dart
+++ b/example/lib/pages/playground/widgets/sections/feature_toggles_section.dart
@@ -7,16 +7,19 @@ import '../settings_controls.dart';
 class FeatureTogglesSection extends StatelessWidget {
   final PlaygroundSettings settings;
   final ValueChanged<PlaygroundSettings> onSettingsChanged;
+  final String query;
 
   const FeatureTogglesSection({
     super.key,
     required this.settings,
     required this.onSettingsChanged,
+    this.query = '',
   });
 
   @override
   Widget build(BuildContext context) {
     return buildSection(
+      query: query,
       title: 'Feature Toggles',
       icon: Icons.toggle_on,
       color: Colors.orange.shade700,

--- a/example/lib/pages/playground/widgets/sections/header_border_section.dart
+++ b/example/lib/pages/playground/widgets/sections/header_border_section.dart
@@ -30,19 +30,17 @@ class HeaderBorderSection extends StatelessWidget {
           },
         ),
         if (settings.headerTopBorderShow)
-          Padding(
-            padding: const EdgeInsets.only(left: 8),
-            child: buildSliderSetting(
-              label: 'Thickness',
-              value: settings.headerTopBorderThickness,
-              min: 0.5,
-              max: 6,
-              unit: 'px',
-              onChanged: (value) {
-                onSettingsChanged(
-                    settings.copyWith(headerTopBorderThickness: value));
-              },
-            ),
+          buildSliderSetting(
+            label: 'Thickness',
+            value: settings.headerTopBorderThickness,
+            min: 0.5,
+            max: 6,
+            unit: 'px',
+            onChanged: (value) {
+              onSettingsChanged(
+                  settings.copyWith(headerTopBorderThickness: value));
+            },
+            indent: true,
           ),
         const SizedBox(height: 4),
 
@@ -55,19 +53,17 @@ class HeaderBorderSection extends StatelessWidget {
           },
         ),
         if (settings.headerBottomBorderShow)
-          Padding(
-            padding: const EdgeInsets.only(left: 8),
-            child: buildSliderSetting(
-              label: 'Thickness',
-              value: settings.headerBottomBorderThickness,
-              min: 0.5,
-              max: 6,
-              unit: 'px',
-              onChanged: (value) {
-                onSettingsChanged(
-                    settings.copyWith(headerBottomBorderThickness: value));
-              },
-            ),
+          buildSliderSetting(
+            label: 'Thickness',
+            value: settings.headerBottomBorderThickness,
+            min: 0.5,
+            max: 6,
+            unit: 'px',
+            onChanged: (value) {
+              onSettingsChanged(
+                  settings.copyWith(headerBottomBorderThickness: value));
+            },
+            indent: true,
           ),
 
         const Divider(height: 24),
@@ -82,49 +78,43 @@ class HeaderBorderSection extends StatelessWidget {
           },
         ),
         if (settings.headerVerticalDividerShow) ...[
-          Padding(
-            padding: const EdgeInsets.only(left: 8),
-            child: buildSliderSetting(
-              label: 'Thickness',
-              value: settings.headerVerticalDividerThickness,
-              min: 0.5,
-              max: 6,
-              unit: 'px',
-              onChanged: (value) {
-                onSettingsChanged(
-                    settings.copyWith(headerVerticalDividerThickness: value));
-              },
-            ),
+          buildSliderSetting(
+            label: 'Thickness',
+            value: settings.headerVerticalDividerThickness,
+            min: 0.5,
+            max: 6,
+            unit: 'px',
+            onChanged: (value) {
+              onSettingsChanged(
+                  settings.copyWith(headerVerticalDividerThickness: value));
+            },
+            indent: true,
           ),
           const SizedBox(height: 8),
-          Padding(
-            padding: const EdgeInsets.only(left: 8),
-            child: buildSliderSetting(
-              label: 'Indent (top)',
-              value: settings.headerVerticalDividerIndent,
-              min: 0,
-              max: 24,
-              unit: 'px',
-              onChanged: (value) {
-                onSettingsChanged(
-                    settings.copyWith(headerVerticalDividerIndent: value));
-              },
-            ),
+          buildSliderSetting(
+            label: 'Indent (top)',
+            value: settings.headerVerticalDividerIndent,
+            min: 0,
+            max: 24,
+            unit: 'px',
+            onChanged: (value) {
+              onSettingsChanged(
+                  settings.copyWith(headerVerticalDividerIndent: value));
+            },
+            indent: true,
           ),
           const SizedBox(height: 8),
-          Padding(
-            padding: const EdgeInsets.only(left: 8),
-            child: buildSliderSetting(
-              label: 'End Indent (bottom)',
-              value: settings.headerVerticalDividerEndIndent,
-              min: 0,
-              max: 24,
-              unit: 'px',
-              onChanged: (value) {
-                onSettingsChanged(
-                    settings.copyWith(headerVerticalDividerEndIndent: value));
-              },
-            ),
+          buildSliderSetting(
+            label: 'End Indent (bottom)',
+            value: settings.headerVerticalDividerEndIndent,
+            min: 0,
+            max: 24,
+            unit: 'px',
+            onChanged: (value) {
+              onSettingsChanged(
+                  settings.copyWith(headerVerticalDividerEndIndent: value));
+            },
+            indent: true,
           ),
         ],
 

--- a/example/lib/pages/playground/widgets/sections/header_border_section.dart
+++ b/example/lib/pages/playground/widgets/sections/header_border_section.dart
@@ -6,16 +6,19 @@ import '../settings_controls.dart';
 class HeaderBorderSection extends StatelessWidget {
   final PlaygroundSettings settings;
   final ValueChanged<PlaygroundSettings> onSettingsChanged;
+  final String query;
 
   const HeaderBorderSection({
     super.key,
     required this.settings,
     required this.onSettingsChanged,
+    this.query = '',
   });
 
   @override
   Widget build(BuildContext context) {
     return buildSection(
+      query: query,
       title: 'Header Border / Divider',
       icon: Icons.border_all,
       color: Colors.teal.shade700,

--- a/example/lib/pages/playground/widgets/sections/style_settings_section.dart
+++ b/example/lib/pages/playground/widgets/sections/style_settings_section.dart
@@ -6,18 +6,21 @@ import '../settings_controls.dart';
 class StyleSettingsSection extends StatelessWidget {
   final PlaygroundSettings settings;
   final ValueChanged<PlaygroundSettings> onSettingsChanged;
+  final String query;
   final VoidCallback? onRandomizeWidths;
 
   const StyleSettingsSection({
     super.key,
     required this.settings,
     required this.onSettingsChanged,
+    this.query = '',
     this.onRandomizeWidths,
   });
 
   @override
   Widget build(BuildContext context) {
     return buildSection(
+      query: query,
       title: 'Style Settings',
       icon: Icons.palette,
       color: Colors.purple.shade700,

--- a/example/lib/pages/playground/widgets/sections/tooltip_settings_section.dart
+++ b/example/lib/pages/playground/widgets/sections/tooltip_settings_section.dart
@@ -7,16 +7,19 @@ import '../settings_controls.dart';
 class TooltipSettingsSection extends StatelessWidget {
   final PlaygroundSettings settings;
   final ValueChanged<PlaygroundSettings> onSettingsChanged;
+  final String query;
 
   const TooltipSettingsSection({
     super.key,
     required this.settings,
     required this.onSettingsChanged,
+    this.query = '',
   });
 
   @override
   Widget build(BuildContext context) {
     return buildSection(
+      query: query,
       title: 'Tooltip Settings',
       icon: Icons.chat_bubble_outline,
       color: Colors.indigo.shade700,

--- a/example/lib/pages/playground/widgets/settings_controls.dart
+++ b/example/lib/pages/playground/widgets/settings_controls.dart
@@ -2,6 +2,37 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
+/// One labelled control in the settings panel.
+///
+/// The label travels with the widget rather than being buried inside it, so a
+/// section can ask what its children are before it builds them — which is what
+/// searching across 68 controls needs and a bare `Widget` cannot answer.
+class SettingsControl extends StatelessWidget {
+  const SettingsControl({
+    super.key,
+    required this.label,
+    required this.child,
+    this.indent = false,
+  });
+
+  /// The text the user reads, and the text a search matches against.
+  final String label;
+
+  /// Whether this control belongs under the one above it.
+  final bool indent;
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!indent) return child;
+    return Padding(
+      padding: const EdgeInsets.only(left: 8),
+      child: child,
+    );
+  }
+}
+
 /// The controls the settings panel is built from. Each is pure: it renders what
 /// it is handed and reports back through its callback, knowing nothing of
 /// PlaygroundSettings or of which section it sits in.
@@ -38,7 +69,7 @@ Widget buildSection({
   );
 }
 
-Widget buildSliderSetting({
+SettingsControl buildSliderSetting({
   required String label,
   required double value,
   required double min,
@@ -46,56 +77,99 @@ Widget buildSliderSetting({
   required String unit,
   required ValueChanged<double> onChanged,
   int decimalPlaces = 0,
+  bool indent = false,
 }) {
   final displayValue = decimalPlaces > 0
       ? value.toStringAsFixed(decimalPlaces)
       : '${value.round()}';
-  return Column(
-    crossAxisAlignment: CrossAxisAlignment.start,
-    children: [
-      Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text(
-            label,
-            style: const TextStyle(
-              fontSize: 13,
-              fontWeight: FontWeight.w500,
+  return SettingsControl(
+    label: label,
+    indent: indent,
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              label,
+              style: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w500,
+              ),
             ),
-          ),
-          Text(
-            '$displayValue$unit',
-            style: TextStyle(
-              fontSize: 13,
-              fontWeight: FontWeight.bold,
-              color: Colors.purple.shade700,
+            Text(
+              '$displayValue$unit',
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.bold,
+                color: Colors.purple.shade700,
+              ),
             ),
-          ),
-        ],
-      ),
-      Slider(
-        value: value,
-        min: min,
-        max: max,
-        divisions: ((max - min) / (decimalPlaces > 0 ? 0.05 : 2)).round(),
-        onChanged: onChanged,
-      ),
-    ],
+          ],
+        ),
+        Slider(
+          value: value,
+          min: min,
+          max: max,
+          divisions: ((max - min) / (decimalPlaces > 0 ? 0.05 : 2)).round(),
+          onChanged: onChanged,
+        ),
+      ],
+    ),
   );
 }
 
-Widget buildSwitchTile({
+SettingsControl buildSwitchTile({
   required String label,
   required bool value,
   required ValueChanged<bool> onChanged,
+  bool indent = false,
 }) {
-  return Padding(
-    padding: const EdgeInsets.symmetric(vertical: 4),
+  return SettingsControl(
+    label: label,
+    indent: indent,
+    child: Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          // The panel is a fixed 380 wide. The label has to yield the space the
+          // control needs, not push it off the edge — a wider text scale, or a
+          // longer translation, will ask it to.
+          Expanded(
+            child: Text(
+              label,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+          Switch(
+            value: value,
+            onChanged: onChanged,
+            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+SettingsControl buildDropdownRow<T>({
+  required String label,
+  required T value,
+  required List<T> items,
+  required String Function(T) itemLabel,
+  required ValueChanged<T> onChanged,
+  bool indent = false,
+}) {
+  return SettingsControl(
+    label: label,
+    indent: indent,
     child: Row(
       children: [
-        // The panel is a fixed 380 wide. The label has to yield the space the
-        // control needs, not push it off the edge — a wider text scale, or a
-        // longer translation, will ask it to.
         Expanded(
           child: Text(
             label,
@@ -106,55 +180,28 @@ Widget buildSwitchTile({
             ),
           ),
         ),
-        Switch(
+        DropdownButton<T>(
           value: value,
-          onChanged: onChanged,
-          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          onChanged: (T? newValue) {
+            if (newValue != null) onChanged(newValue);
+          },
+          items: items.map((item) {
+            return DropdownMenuItem(
+              value: item,
+              child: Text(
+                itemLabel(item),
+                style: const TextStyle(fontSize: 13),
+              ),
+            );
+          }).toList(),
         ),
       ],
     ),
   );
 }
 
-Widget buildDropdownRow<T>({
+SettingsControl buildLogSlider({
   required String label,
-  required T value,
-  required List<T> items,
-  required String Function(T) itemLabel,
-  required ValueChanged<T> onChanged,
-}) {
-  return Row(
-    children: [
-      Expanded(
-        child: Text(
-          label,
-          overflow: TextOverflow.ellipsis,
-          style: const TextStyle(
-            fontSize: 14,
-            fontWeight: FontWeight.w500,
-          ),
-        ),
-      ),
-      DropdownButton<T>(
-        value: value,
-        onChanged: (T? newValue) {
-          if (newValue != null) onChanged(newValue);
-        },
-        items: items.map((item) {
-          return DropdownMenuItem(
-            value: item,
-            child: Text(
-              itemLabel(item),
-              style: const TextStyle(fontSize: 13),
-            ),
-          );
-        }).toList(),
-      ),
-    ],
-  );
-}
-
-Widget buildLogSlider({
   required double value,
   required double min,
   required double max,
@@ -165,15 +212,18 @@ Widget buildLogSlider({
   final logMax = math.log(max) / math.ln10;
   final logValue = math.log(value) / math.ln10;
 
-  return Slider(
-    value: logValue,
-    min: logMin,
-    max: logMax,
-    divisions: 100,
-    onChanged: (logVal) {
-      final actualValue = math.pow(10, logVal).toDouble();
-      onChanged(actualValue);
-    },
+  return SettingsControl(
+    label: label,
+    child: Slider(
+      value: logValue,
+      min: logMin,
+      max: logMax,
+      divisions: 100,
+      onChanged: (logVal) {
+        final actualValue = math.pow(10, logVal).toDouble();
+        onChanged(actualValue);
+      },
+    ),
   );
 }
 

--- a/example/lib/pages/playground/widgets/settings_controls.dart
+++ b/example/lib/pages/playground/widgets/settings_controls.dart
@@ -2,6 +2,17 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
+/// Whether a control named [label] should survive a search for [query].
+///
+/// A blank query is not a search, so everything survives it. Otherwise the
+/// query is a substring of the label, in any case and anywhere within it —
+/// someone hunting the tooltip anchors types "anchor", not "Cell Anchor".
+bool settingMatches(String label, String query) {
+  final needle = query.trim().toLowerCase();
+  if (needle.isEmpty) return true;
+  return label.toLowerCase().contains(needle);
+}
+
 /// One labelled control in the settings panel.
 ///
 /// The label travels with the widget rather than being buried inside it, so a
@@ -43,30 +54,122 @@ Widget buildSection({
   required Color borderColor,
   required List<Widget> children,
   bool initiallyExpanded = false,
+  String query = '',
 }) {
-  return Container(
-    decoration: BoxDecoration(
-      color: Colors.white,
-      borderRadius: BorderRadius.circular(8),
-      border: Border.all(color: borderColor),
-    ),
-    clipBehavior: Clip.antiAlias,
-    child: ExpansionTile(
-      tilePadding: const EdgeInsets.symmetric(horizontal: 16),
-      childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-      initiallyExpanded: initiallyExpanded,
-      leading: Icon(icon, color: color, size: 20),
-      title: Text(
-        title,
-        style: TextStyle(
-          fontSize: 16,
-          fontWeight: FontWeight.w600,
-          color: color,
-        ),
-      ),
-      children: children,
-    ),
+  return SettingsSection(
+    title: title,
+    icon: icon,
+    color: color,
+    borderColor: borderColor,
+    initiallyExpanded: initiallyExpanded,
+    query: query,
+    children: children,
   );
+}
+
+/// A collapsible group of controls, which a search can see through.
+///
+/// While [query] is blank the section behaves as it always has: it remembers
+/// whether the reader opened it. While a search is running it shows only the
+/// [SettingsControl]s whose labels match, opens itself to show them, and stands
+/// aside entirely when it holds none — and it does not disturb the expanded
+/// state it will go back to once the query is cleared.
+class SettingsSection extends StatefulWidget {
+  const SettingsSection({
+    super.key,
+    required this.title,
+    required this.icon,
+    required this.color,
+    required this.borderColor,
+    required this.children,
+    this.initiallyExpanded = false,
+    this.query = '',
+  });
+
+  final String title;
+  final IconData icon;
+  final Color color;
+  final Color borderColor;
+  final List<Widget> children;
+  final bool initiallyExpanded;
+  final String query;
+
+  @override
+  State<SettingsSection> createState() => _SettingsSectionState();
+}
+
+class _SettingsSectionState extends State<SettingsSection> {
+  late bool _expanded = widget.initiallyExpanded;
+
+  bool get _searching => widget.query.trim().isNotEmpty;
+
+  /// Under a search, only the labelled controls survive. The dividers, spacers
+  /// and explanatory notes between them belong to the section as it reads, not
+  /// to the control the reader is hunting for.
+  List<Widget> get _visibleChildren {
+    if (!_searching) return widget.children;
+    return widget.children
+        .whereType<SettingsControl>()
+        .where((c) => settingMatches(c.label, widget.query))
+        .toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final children = _visibleChildren;
+    if (_searching && children.isEmpty) return const SizedBox.shrink();
+
+    final expanded = _searching || _expanded;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: widget.borderColor),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          InkWell(
+            // A search decides what is open, so the header stops taking taps
+            // while one is running rather than fighting it.
+            onTap:
+                _searching ? null : () => setState(() => _expanded = !expanded),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  Icon(widget.icon, color: widget.color, size: 20),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Text(
+                      widget.title,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                        color: widget.color,
+                      ),
+                    ),
+                  ),
+                  Icon(expanded ? Icons.expand_less : Icons.expand_more),
+                ],
+              ),
+            ),
+          ),
+          if (expanded)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: children,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
 }
 
 SettingsControl buildSliderSetting({

--- a/example/lib/pages/playground/widgets/settings_panel.dart
+++ b/example/lib/pages/playground/widgets/settings_panel.dart
@@ -15,7 +15,7 @@ import 'sections/tooltip_settings_section.dart';
 /// - Table styling (row height, font size, padding)
 /// - Feature toggles (sorting, selection, editing, etc.)
 /// - Performance monitoring display
-class SettingsPanel extends StatelessWidget {
+class SettingsPanel extends StatefulWidget {
   final PlaygroundSettings settings;
   final PerformanceMetrics performanceMetrics;
   final ValueChanged<PlaygroundSettings> onSettingsChanged;
@@ -40,7 +40,21 @@ class SettingsPanel extends StatelessWidget {
   });
 
   @override
+  State<SettingsPanel> createState() => _SettingsPanelState();
+}
+
+class _SettingsPanelState extends State<SettingsPanel> {
+  final _search = TextEditingController();
+
+  @override
+  void dispose() {
+    _search.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final query = _search.text;
     return Container(
       width: 380,
       height: double.infinity,
@@ -57,26 +71,45 @@ class SettingsPanel extends StatelessWidget {
           children: [
             // Header
             _buildHeader(),
+            const SizedBox(height: 16),
+
+            TextField(
+              controller: _search,
+              onChanged: (_) => setState(() {}),
+              decoration: InputDecoration(
+                isDense: true,
+                hintText: 'Search settings',
+                prefixIcon: const Icon(Icons.search, size: 20),
+                suffixIcon: query.isEmpty
+                    ? null
+                    : IconButton(
+                        icon: const Icon(Icons.clear, size: 18),
+                        onPressed: () => setState(_search.clear),
+                      ),
+                border: const OutlineInputBorder(),
+              ),
+            ),
             const SizedBox(height: 24),
 
             // Data Settings
             DataSettingsSection(
-              settings: settings,
-              onSettingsChanged: onSettingsChanged,
-              onGenerateData: onGenerateData,
-              isGenerating: isGenerating,
+              query: query,
+              settings: widget.settings,
+              onSettingsChanged: widget.onSettingsChanged,
+              onGenerateData: widget.onGenerateData,
+              isGenerating: widget.isGenerating,
             ),
             const SizedBox(height: 16),
 
             // Width persistence demo buttons
-            if (onRestoreWidths != null)
+            if (widget.onRestoreWidths != null)
               Row(
                 children: [
                   Expanded(
                     child: SizedBox(
                       height: 44,
                       child: OutlinedButton.icon(
-                        onPressed: onRandomSavedWidths,
+                        onPressed: widget.onRandomSavedWidths,
                         icon: const Icon(Icons.shuffle, size: 18),
                         label: const Text('Random'),
                         style: OutlinedButton.styleFrom(
@@ -91,13 +124,15 @@ class SettingsPanel extends StatelessWidget {
                     child: SizedBox(
                       height: 44,
                       child: OutlinedButton.icon(
-                        onPressed: hasSavedWidths ? onRestoreWidths : null,
+                        onPressed: widget.hasSavedWidths
+                            ? widget.onRestoreWidths
+                            : null,
                         icon: const Icon(Icons.restore, size: 18),
                         label: const Text('Restore'),
                         style: OutlinedButton.styleFrom(
                           foregroundColor: Colors.orange.shade700,
                           side: BorderSide(
-                            color: hasSavedWidths
+                            color: widget.hasSavedWidths
                                 ? Colors.orange.shade400
                                 : Colors.grey.shade300,
                           ),
@@ -111,35 +146,39 @@ class SettingsPanel extends StatelessWidget {
 
             // Style Settings
             StyleSettingsSection(
-              settings: settings,
-              onSettingsChanged: onSettingsChanged,
-              onRandomizeWidths: onRandomizeWidths,
+              query: query,
+              settings: widget.settings,
+              onSettingsChanged: widget.onSettingsChanged,
+              onRandomizeWidths: widget.onRandomizeWidths,
             ),
             const SizedBox(height: 24),
 
             // Header Border/Divider Settings
             HeaderBorderSection(
-              settings: settings,
-              onSettingsChanged: onSettingsChanged,
+              query: query,
+              settings: widget.settings,
+              onSettingsChanged: widget.onSettingsChanged,
             ),
             const SizedBox(height: 24),
 
             // Feature Toggles
             FeatureTogglesSection(
-              settings: settings,
-              onSettingsChanged: onSettingsChanged,
+              query: query,
+              settings: widget.settings,
+              onSettingsChanged: widget.onSettingsChanged,
             ),
             const SizedBox(height: 24),
 
             // Tooltip Settings
             TooltipSettingsSection(
-              settings: settings,
-              onSettingsChanged: onSettingsChanged,
+              query: query,
+              settings: widget.settings,
+              onSettingsChanged: widget.onSettingsChanged,
             ),
             const SizedBox(height: 24),
 
             // Performance Monitor
-            PerformanceMonitor(metrics: performanceMetrics),
+            PerformanceMonitor(metrics: widget.performanceMetrics),
           ],
         ),
       ),

--- a/example/test/settings_panel_test.dart
+++ b/example/test/settings_panel_test.dart
@@ -1,5 +1,6 @@
 import 'package:example/pages/playground/models/playground_settings.dart';
 import 'package:example/pages/playground/widgets/performance_monitor.dart';
+import 'package:example/pages/playground/widgets/settings_controls.dart';
 import 'package:example/pages/playground/widgets/settings_panel.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -21,16 +22,21 @@ const _sectionTitles = [
   'Tooltip Settings',
 ];
 
-/// Only 'Data Settings' starts expanded, and a collapsed [ExpansionTile] does
-/// not build its children — so nothing can be counted until each section is
-/// opened.
+/// Only 'Data Settings' starts expanded, and a collapsed section does not build
+/// its children — so nothing can be counted until each is opened.
+///
+/// A section is collapsed when its header offers to expand it. That is what the
+/// reader sees, and it survived the move off `ExpansionTile`, which a search has
+/// to see through and so could not stay.
 Future<void> _expandEverySection(WidgetTester tester) async {
   for (final title in _sectionTitles) {
-    final tile = find.ancestor(
+    final section = find.ancestor(
       of: find.text(title),
-      matching: find.byType(ExpansionTile),
+      matching: find.byType(SettingsSection),
     );
-    if (tester.widget<ExpansionTile>(tile).initiallyExpanded) continue;
+    final collapsed =
+        find.descendant(of: section, matching: find.byIcon(Icons.expand_more));
+    if (collapsed.evaluate().isEmpty) continue;
 
     await tester.ensureVisible(find.text(title));
     await tester.pumpAndSettle();
@@ -76,6 +82,42 @@ void main() {
     expect(
         find.byWidgetPredicate((w) => w is DropdownButton), findsNWidgets(12));
     expect(find.byType(Slider), findsNWidgets(20));
+  });
+
+  testWidgets('a search narrows the panel to the controls that match',
+      (tester) async {
+    await tester.pumpWidget(_panel());
+
+    await tester.enterText(find.byType(TextField), 'anchor');
+    await tester.pumpAndSettle();
+
+    // Both anchors live in the last section, which starts collapsed. A match
+    // inside it has to reveal it, or the search would find nothing.
+    expect(find.text('Cell Anchor'), findsOneWidget);
+    expect(find.text('Header Anchor'), findsOneWidget);
+
+    // A section with no match makes no noise, and neither do the controls of
+    // the section that starts open.
+    expect(find.text('Data Settings'), findsNothing);
+    expect(find.text('Row Count'), findsNothing);
+  });
+
+  testWidgets('clearing the search restores what was open before it',
+      (tester) async {
+    await tester.pumpWidget(_panel());
+    expect(find.text('Row Count'), findsOneWidget,
+        reason: 'the data section starts expanded');
+
+    await tester.enterText(find.byType(TextField), 'anchor');
+    await tester.pumpAndSettle();
+    expect(find.text('Row Count'), findsNothing);
+
+    await tester.enterText(find.byType(TextField), '');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Row Count'), findsOneWidget);
+    expect(find.text('Cell Anchor'), findsNothing,
+        reason: 'the tooltip section was closed before the search opened it');
   });
 
   testWidgets('the tooltip anchors are reachable', (tester) async {

--- a/example/test/settings_search_test.dart
+++ b/example/test/settings_search_test.dart
@@ -1,0 +1,31 @@
+import 'package:example/pages/playground/widgets/settings_controls.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('settingMatches', () {
+    test('an empty query matches everything', () {
+      expect(settingMatches('Row Count', ''), isTrue);
+      expect(settingMatches('', ''), isTrue);
+    });
+
+    test('matches on any part of the label, not just its start', () {
+      expect(settingMatches('Cell Anchor', 'anchor'), isTrue);
+      expect(settingMatches('Header Anchor', 'head'), isTrue);
+    });
+
+    test('ignores case on both sides', () {
+      expect(settingMatches('Row Count', 'ROW'), isTrue);
+      expect(settingMatches('ROW COUNT', 'row'), isTrue);
+    });
+
+    test('ignores surrounding whitespace in the query', () {
+      expect(settingMatches('Row Count', '  count '), isTrue);
+      expect(settingMatches('Row Count', '   '), isTrue,
+          reason: 'a query of only spaces is no query at all');
+    });
+
+    test('does not match a label it is absent from', () {
+      expect(settingMatches('Row Count', 'anchor'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Closes #62

Sixty-eight controls across five sections, and no way to find one except to remember which section holds it. The tooltip controls sit in the last, which is why the ones added most recently are the hardest to reach. Reordering the sections would only move the problem to whichever ends up last.

Typing narrows the panel to the controls whose labels match. A section holding a match opens itself to show them; a section holding none stands aside. Clearing the search puts every section back the way the reader left it.

## A Widget will not tell you what it is

The panel's children were bare `Widget`s, and filtering by name has to ask each one what it is called. So the four control helpers now return a `SettingsControl`: the label travels beside the widget instead of being buried inside it, and a section can read its children before it builds them.

Indentation came along for the same reason. A control nested under the one above it was wrapped in a `Padding` by its section — and that wrapper hid the control from anyone walking the children. It is now the control's own `indent` flag.

Only labelled controls survive a query. The dividers, spacers and explanatory notes between them belong to the section as it reads, not to the control someone is hunting for.

## ExpansionTile could not stay

It owns its expanded state, so a search could not open a section without stealing the state it must give back when the query clears. And it would not tell a section what its children were.

The replacement keeps the reader's model — a header that toggles, an arrow that says which way — and adds the two things a search needs: a section that lends its expansion to the query rather than surrendering it, and one that can see its own contents. While a search is running the header stops taking taps, because the search is deciding what is open and the two should not fight.

## The characterisation test was updated, not abandoned

`#59` left a test that counts every control without naming any of them, and `#65` removed the text-shrinking workaround it once needed. It found sections by `find.byType(ExpansionTile)`, which is an observation coupled to the implementation, and it broke the moment the implementation changed.

It now finds a collapsed section by the arrow its header shows — what a reader sees, and what survives the widget underneath being replaced. It still counts the same 25 switches, 12 dropdowns and 20 sliders.

## Verification

`cd example && flutter test` passes (26 tests), the package's 378 are untouched and green, `flutter analyze` is clean in both, `dart format` leaves both unchanged, no overflow under the widget-test font. Disabling the filter reproduces the failure in both search tests. Driven and confirmed on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)