### PR TITLE
A settings control carries its id, not only its label

### DIFF
--- a/example/lib/pages/playground/widgets/sections/data_settings_section.dart
+++ b/example/lib/pages/playground/widgets/sections/data_settings_section.dart
@@ -63,6 +63,7 @@ class DataSettingsSection extends StatelessWidget {
 
         // Logarithmic slider (5 to 100,000)
         buildLogSlider(
+          id: 'rowCount',
           label: 'Row Count',
           value: settings.rowCount.toDouble(),
           min: 5,

--- a/example/lib/pages/playground/widgets/sections/feature_toggles_section.dart
+++ b/example/lib/pages/playground/widgets/sections/feature_toggles_section.dart
@@ -28,6 +28,7 @@ class FeatureTogglesSection extends StatelessWidget {
         const SizedBox(height: 12),
 
         buildSwitchTile(
+          id: 'sortingEnabled',
           label: 'Sorting',
           value: settings.sortingEnabled,
           onChanged: (value) {
@@ -36,6 +37,7 @@ class FeatureTogglesSection extends StatelessWidget {
         ),
 
         buildSwitchTile(
+          id: 'editingEnabled',
           label: 'Editing',
           value: settings.editingEnabled,
           onChanged: (value) {
@@ -44,6 +46,7 @@ class FeatureTogglesSection extends StatelessWidget {
         ),
 
         buildSwitchTile(
+          id: 'columnReorderEnabled',
           label: 'Column Reorder',
           value: settings.columnReorderEnabled,
           onChanged: (value) {
@@ -52,6 +55,7 @@ class FeatureTogglesSection extends StatelessWidget {
         ),
 
         buildSwitchTile(
+          id: 'resizableEnabled',
           label: 'Column Resize',
           value: settings.resizableEnabled,
           onChanged: (value) {
@@ -60,6 +64,7 @@ class FeatureTogglesSection extends StatelessWidget {
         ),
 
         buildSwitchTile(
+          id: 'stretchLastColumn',
           label: 'Stretch Last Column',
           value: settings.stretchLastColumn,
           onChanged: (value) {
@@ -68,6 +73,7 @@ class FeatureTogglesSection extends StatelessWidget {
         ),
 
         buildSwitchTile(
+          id: 'showAlternateRows',
           label: 'Alternate Rows',
           value: settings.showAlternateRows,
           onChanged: (value) {
@@ -76,6 +82,7 @@ class FeatureTogglesSection extends StatelessWidget {
         ),
 
         buildSwitchTile(
+          id: 'rowCardTooltip',
           label: 'Row Card Tooltip',
           value: settings.rowCardTooltip,
           onChanged: (value) {
@@ -84,6 +91,7 @@ class FeatureTogglesSection extends StatelessWidget {
         ),
 
         buildDropdownRow<InkColorOption>(
+          id: 'splashColor',
           label: 'Splash Color',
           value: settings.splashColor,
           items: InkColorOption.values,
@@ -94,6 +102,7 @@ class FeatureTogglesSection extends StatelessWidget {
         ),
 
         buildDropdownRow<InkColorOption>(
+          id: 'hoverColor',
           label: 'Hover Color',
           value: settings.hoverColor,
           items: InkColorOption.values,
@@ -104,6 +113,7 @@ class FeatureTogglesSection extends StatelessWidget {
         ),
 
         buildDropdownRow<InkColorOption>(
+          id: 'highlightColor',
           label: 'Highlight Color',
           value: settings.highlightColor,
           items: InkColorOption.values,
@@ -124,6 +134,7 @@ class FeatureTogglesSection extends StatelessWidget {
         ),
 
         buildSwitchTile(
+          id: 'showDividers',
           label: 'Show Dividers',
           value: settings.showDividers,
           onChanged: (value) {
@@ -132,6 +143,7 @@ class FeatureTogglesSection extends StatelessWidget {
         ),
 
         buildSwitchTile(
+          id: 'mergedRowsEnabled',
           label: 'Merged Rows',
           value: settings.mergedRowsEnabled,
           onChanged: (value) {
@@ -140,6 +152,7 @@ class FeatureTogglesSection extends StatelessWidget {
         ),
 
         buildSwitchTile(
+          id: 'dynamicRowHeight',
           label: 'Dynamic Row Height',
           value: settings.dynamicRowHeight,
           onChanged: (value) {
@@ -148,6 +161,7 @@ class FeatureTogglesSection extends StatelessWidget {
         ),
 
         buildSwitchTile(
+          id: 'dimInactiveRows',
           label: 'Dim Inactive Rows',
           value: settings.dimInactiveRows,
           onChanged: (value) {
@@ -156,6 +170,7 @@ class FeatureTogglesSection extends StatelessWidget {
         ),
 
         buildSwitchTile(
+          id: 'selectionEnabled',
           label: 'Selection (Checkbox)',
           value: settings.selectionEnabled,
           onChanged: (value) {
@@ -165,6 +180,7 @@ class FeatureTogglesSection extends StatelessWidget {
 
         if (settings.selectionEnabled) ...[
           buildSwitchTile(
+            id: 'showCheckboxColumn',
             label: 'Show Checkbox Column',
             value: settings.showCheckboxColumn,
             onChanged: (value) {
@@ -172,6 +188,7 @@ class FeatureTogglesSection extends StatelessWidget {
             },
           ),
           buildSwitchTile(
+            id: 'selectAllEnabled',
             label: 'Select All',
             value: settings.selectAllEnabled,
             onChanged: (value) {
@@ -179,6 +196,7 @@ class FeatureTogglesSection extends StatelessWidget {
             },
           ),
           buildSwitchTile(
+            id: 'dragSelectionEnabled',
             label: 'Drag Selection',
             value: settings.dragSelectionEnabled,
             onChanged: (value) {
@@ -186,6 +204,7 @@ class FeatureTogglesSection extends StatelessWidget {
             },
           ),
           buildSwitchTile(
+            id: 'cellTapTogglesCheckbox',
             label: 'Cell Tap Toggles Checkbox',
             value: settings.cellTapTogglesCheckbox,
             onChanged: (value) {
@@ -194,6 +213,7 @@ class FeatureTogglesSection extends StatelessWidget {
             },
           ),
           buildSwitchTile(
+            id: 'showRowCheckbox',
             label: 'Show Row Checkbox',
             value: settings.showRowCheckbox,
             onChanged: (value) {
@@ -208,6 +228,7 @@ class FeatureTogglesSection extends StatelessWidget {
 
         // Selection mode dropdown
         buildDropdownRow<SelectionMode>(
+          id: 'selectionMode',
           label: 'Selection Mode',
           value: settings.selectionMode,
           items: SelectionMode.values,
@@ -220,6 +241,7 @@ class FeatureTogglesSection extends StatelessWidget {
 
         // Sort cycle order dropdown
         buildDropdownRow<SortCycleOrder>(
+          id: 'sortCycleOrder',
           label: 'Sort Cycle',
           value: settings.sortCycleOrder,
           items: SortCycleOrder.values,

--- a/example/lib/pages/playground/widgets/sections/header_border_section.dart
+++ b/example/lib/pages/playground/widgets/sections/header_border_section.dart
@@ -26,6 +26,7 @@ class HeaderBorderSection extends StatelessWidget {
       children: [
         // --- Top Border ---
         buildSwitchTile(
+          id: 'headerTopBorderShow',
           label: 'Top Border',
           value: settings.headerTopBorderShow,
           onChanged: (value) {
@@ -34,6 +35,7 @@ class HeaderBorderSection extends StatelessWidget {
         ),
         if (settings.headerTopBorderShow)
           buildSliderSetting(
+            id: 'headerTopBorderThickness',
             label: 'Thickness',
             value: settings.headerTopBorderThickness,
             min: 0.5,
@@ -49,6 +51,7 @@ class HeaderBorderSection extends StatelessWidget {
 
         // --- Bottom Border ---
         buildSwitchTile(
+          id: 'headerBottomBorderShow',
           label: 'Bottom Border',
           value: settings.headerBottomBorderShow,
           onChanged: (value) {
@@ -57,6 +60,7 @@ class HeaderBorderSection extends StatelessWidget {
         ),
         if (settings.headerBottomBorderShow)
           buildSliderSetting(
+            id: 'headerBottomBorderThickness',
             label: 'Thickness',
             value: settings.headerBottomBorderThickness,
             min: 0.5,
@@ -73,6 +77,7 @@ class HeaderBorderSection extends StatelessWidget {
 
         // --- Vertical Divider ---
         buildSwitchTile(
+          id: 'headerVerticalDividerShow',
           label: 'Vertical Divider',
           value: settings.headerVerticalDividerShow,
           onChanged: (value) {
@@ -82,6 +87,7 @@ class HeaderBorderSection extends StatelessWidget {
         ),
         if (settings.headerVerticalDividerShow) ...[
           buildSliderSetting(
+            id: 'headerVerticalDividerThickness',
             label: 'Thickness',
             value: settings.headerVerticalDividerThickness,
             min: 0.5,
@@ -95,6 +101,7 @@ class HeaderBorderSection extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           buildSliderSetting(
+            id: 'headerVerticalDividerIndent',
             label: 'Indent (top)',
             value: settings.headerVerticalDividerIndent,
             min: 0,
@@ -108,6 +115,7 @@ class HeaderBorderSection extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           buildSliderSetting(
+            id: 'headerVerticalDividerEndIndent',
             label: 'End Indent (bottom)',
             value: settings.headerVerticalDividerEndIndent,
             min: 0,
@@ -126,6 +134,7 @@ class HeaderBorderSection extends StatelessWidget {
         // --- Resize Handle ---
         if (settings.resizableEnabled) ...[
           buildSliderSetting(
+            id: 'resizeHandleWidth',
             label: 'Handle Hit Width',
             value: settings.resizeHandleWidth,
             min: 4,
@@ -137,6 +146,7 @@ class HeaderBorderSection extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           buildSliderSetting(
+            id: 'resizeHandleThickness',
             label: 'Handle Thickness',
             value: settings.resizeHandleThickness,
             min: 1,
@@ -149,6 +159,7 @@ class HeaderBorderSection extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           buildSliderSetting(
+            id: 'resizeHandleIndent',
             label: 'Handle Indent (top)',
             value: settings.resizeHandleIndent,
             min: 0,
@@ -160,6 +171,7 @@ class HeaderBorderSection extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           buildSliderSetting(
+            id: 'resizeHandleEndIndent',
             label: 'Handle End Indent',
             value: settings.resizeHandleEndIndent,
             min: 0,

--- a/example/lib/pages/playground/widgets/sections/style_settings_section.dart
+++ b/example/lib/pages/playground/widgets/sections/style_settings_section.dart
@@ -30,6 +30,7 @@ class StyleSettingsSection extends StatelessWidget {
 
         // Font family
         buildDropdownRow<String>(
+          id: 'fontFamily',
           label: 'Font Family',
           value: settings.fontFamily,
           items: const [
@@ -55,6 +56,7 @@ class StyleSettingsSection extends StatelessWidget {
 
         // Scale (zoom)
         buildSliderSetting(
+          id: 'scale',
           label: 'Scale',
           value: settings.scale,
           min: 0.25,
@@ -80,6 +82,7 @@ class StyleSettingsSection extends StatelessWidget {
           ),
         ),
         buildSwitchTile(
+          id: 'blockModifierScroll',
           label: 'Block Modifier+Scroll',
           value: settings.blockModifierScroll,
           onChanged: (value) {
@@ -90,6 +93,7 @@ class StyleSettingsSection extends StatelessWidget {
 
         // Column min width
         buildSliderSetting(
+          id: 'columnMinWidth',
           label: 'Col Min Width',
           value: settings.columnMinWidth,
           min: 20,
@@ -119,6 +123,7 @@ class StyleSettingsSection extends StatelessWidget {
 
         // Row height
         buildSliderSetting(
+          id: 'rowHeight',
           label: 'Row Height',
           value: settings.rowHeight,
           min: 30,
@@ -132,6 +137,7 @@ class StyleSettingsSection extends StatelessWidget {
 
         // Font size
         buildSliderSetting(
+          id: 'fontSize',
           label: 'Font Size',
           value: settings.fontSize,
           min: 10,
@@ -145,6 +151,7 @@ class StyleSettingsSection extends StatelessWidget {
 
         // Horizontal padding
         buildSliderSetting(
+          id: 'horizontalPadding',
           label: 'H-Padding',
           value: settings.horizontalPadding,
           min: 4,
@@ -158,6 +165,7 @@ class StyleSettingsSection extends StatelessWidget {
 
         // Vertical padding
         buildSliderSetting(
+          id: 'verticalPadding',
           label: 'V-Padding',
           value: settings.verticalPadding,
           min: 4,
@@ -171,6 +179,7 @@ class StyleSettingsSection extends StatelessWidget {
 
         // Checkbox tap target size
         buildSliderSetting(
+          id: 'checkboxTapTargetSize',
           label: 'Checkbox Tap Size',
           value: settings.checkboxTapTargetSize,
           min: 18,
@@ -184,6 +193,7 @@ class StyleSettingsSection extends StatelessWidget {
 
         // Sort icon width
         buildSliderSetting(
+          id: 'sortIconWidth',
           label: 'Sort Icon Width',
           value: settings.sortIconWidth,
           min: 8,

--- a/example/lib/pages/playground/widgets/sections/tooltip_settings_section.dart
+++ b/example/lib/pages/playground/widgets/sections/tooltip_settings_section.dart
@@ -29,6 +29,7 @@ class TooltipSettingsSection extends StatelessWidget {
 
         // Tooltip enabled toggle
         buildSwitchTile(
+          id: 'tooltipEnabled',
           label: 'Tooltip Enabled',
           value: settings.tooltipEnabled,
           onChanged: (value) {
@@ -48,6 +49,7 @@ class TooltipSettingsSection extends StatelessWidget {
 
           // Cell tooltip behavior
           buildDropdownRow<TooltipBehavior>(
+            id: 'tooltipBehavior',
             label: 'Cell Tooltip',
             value: settings.tooltipBehavior,
             items: TooltipBehavior.values,
@@ -64,6 +66,7 @@ class TooltipSettingsSection extends StatelessWidget {
 
           // Header tooltip behavior
           buildDropdownRow<TooltipBehavior>(
+            id: 'headerTooltipBehavior',
             label: 'Header Tooltip',
             value: settings.headerTooltipBehavior,
             items: TooltipBehavior.values,
@@ -82,6 +85,7 @@ class TooltipSettingsSection extends StatelessWidget {
 
           // Wait duration slider
           buildSliderSetting(
+            id: 'tooltipWaitDurationMs',
             label: 'Wait Duration',
             value: settings.tooltipWaitDurationMs.toDouble(),
             min: 0,
@@ -96,6 +100,7 @@ class TooltipSettingsSection extends StatelessWidget {
           // The card is bigger and more interruptive than a line of text, so
           // it gets its own pause rather than borrowing the cells'.
           buildSliderSetting(
+            id: 'rowCardWaitDurationMs',
             label: 'Row Card Wait',
             value: settings.rowCardWaitDurationMs.toDouble(),
             min: 0,
@@ -111,6 +116,7 @@ class TooltipSettingsSection extends StatelessWidget {
 
           // Direction
           buildDropdownRow<TooltipDirection>(
+            id: 'tooltipDirection',
             label: 'Direction',
             value: settings.tooltipDirection,
             items: TooltipDirection.values,
@@ -128,6 +134,7 @@ class TooltipSettingsSection extends StatelessWidget {
 
           // Anchor — cells
           buildDropdownRow<TooltipAnchor>(
+            id: 'tooltipAnchor',
             label: 'Cell Anchor',
             value: settings.tooltipAnchor,
             items: TooltipAnchor.values,
@@ -149,6 +156,7 @@ class TooltipSettingsSection extends StatelessWidget {
 
           // Anchor — headers
           buildDropdownRow<HeaderTooltipAnchor>(
+            id: 'headerTooltipAnchor',
             label: 'Header Anchor',
             value: settings.headerTooltipAnchor,
             items: HeaderTooltipAnchor.values,
@@ -165,6 +173,7 @@ class TooltipSettingsSection extends StatelessWidget {
 
           // Alignment
           buildDropdownRow<TooltipAlignment>(
+            id: 'tooltipAlignment',
             label: 'Alignment',
             value: settings.tooltipAlignment,
             items: TooltipAlignment.values,
@@ -192,6 +201,7 @@ class TooltipSettingsSection extends StatelessWidget {
 
           // Show Arrow
           buildSwitchTile(
+            id: 'tooltipShowArrow',
             label: 'Show Arrow',
             value: settings.tooltipShowArrow,
             onChanged: (value) {
@@ -201,6 +211,7 @@ class TooltipSettingsSection extends StatelessWidget {
 
           // Offset slider
           buildSliderSetting(
+            id: 'tooltipOffset',
             label: 'Offset',
             value: settings.tooltipOffset,
             min: 0,
@@ -216,6 +227,7 @@ class TooltipSettingsSection extends StatelessWidget {
 
           // Demo: tooltipFormatter
           buildSwitchTile(
+            id: 'showTooltipFormatter',
             label: 'tooltipFormatter (Email)',
             value: settings.showTooltipFormatter,
             onChanged: (value) {
@@ -233,6 +245,7 @@ class TooltipSettingsSection extends StatelessWidget {
 
           // Demo: tooltipBuilder
           buildSwitchTile(
+            id: 'showTooltipBuilder',
             label: 'tooltipBuilder (Name)',
             value: settings.showTooltipBuilder,
             onChanged: (value) {

--- a/example/lib/pages/playground/widgets/settings_controls.dart
+++ b/example/lib/pages/playground/widgets/settings_controls.dart
@@ -21,10 +21,18 @@ bool settingMatches(String label, String query) {
 class SettingsControl extends StatelessWidget {
   const SettingsControl({
     super.key,
+    required this.id,
     required this.label,
     required this.child,
     this.indent = false,
   });
+
+  /// Names the settings field this control edits, and nothing else.
+  ///
+  /// The label is prose: it repeats across sections and a redesign is free to
+  /// rewrite it. The id is what anything wanting to reason about a control —
+  /// which feature owns it, what it depends on — has to hold onto instead.
+  final String id;
 
   /// The text the user reads, and the text a search matches against.
   final String label;
@@ -173,6 +181,7 @@ class _SettingsSectionState extends State<SettingsSection> {
 }
 
 SettingsControl buildSliderSetting({
+  required String id,
   required String label,
   required double value,
   required double min,
@@ -186,6 +195,7 @@ SettingsControl buildSliderSetting({
       ? value.toStringAsFixed(decimalPlaces)
       : '${value.round()}';
   return SettingsControl(
+    id: id,
     label: label,
     indent: indent,
     child: Column(
@@ -224,12 +234,14 @@ SettingsControl buildSliderSetting({
 }
 
 SettingsControl buildSwitchTile({
+  required String id,
   required String label,
   required bool value,
   required ValueChanged<bool> onChanged,
   bool indent = false,
 }) {
   return SettingsControl(
+    id: id,
     label: label,
     indent: indent,
     child: Padding(
@@ -261,6 +273,7 @@ SettingsControl buildSwitchTile({
 }
 
 SettingsControl buildDropdownRow<T>({
+  required String id,
   required String label,
   required T value,
   required List<T> items,
@@ -269,6 +282,7 @@ SettingsControl buildDropdownRow<T>({
   bool indent = false,
 }) {
   return SettingsControl(
+    id: id,
     label: label,
     indent: indent,
     child: Row(
@@ -304,6 +318,7 @@ SettingsControl buildDropdownRow<T>({
 }
 
 SettingsControl buildLogSlider({
+  required String id,
   required String label,
   required double value,
   required double min,
@@ -316,6 +331,7 @@ SettingsControl buildLogSlider({
   final logValue = math.log(value) / math.ln10;
 
   return SettingsControl(
+    id: id,
     label: label,
     child: Slider(
       value: logValue,

--- a/example/test/settings_id_test.dart
+++ b/example/test/settings_id_test.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+
+import 'package:example/pages/playground/models/playground_settings.dart';
+import 'package:example/pages/playground/widgets/performance_monitor.dart';
+import 'package:example/pages/playground/widgets/settings_controls.dart';
+import 'package:example/pages/playground/widgets/settings_panel.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// A control's label is prose: it repeats, and a redesign is free to change it.
+// Its id is the handle the panel holds onto — one per settings field.
+//
+// Dart has no reflection, so "this id names a real field" cannot be asked of
+// the compiler. It is asked of the source instead: the second test reads the
+// settings class and compares its fields to the ids the panel renders.
+
+const _sectionTitles = [
+  'Data Settings',
+  'Style Settings',
+  'Header Border / Divider',
+  'Feature Toggles',
+  'Tooltip Settings',
+];
+
+Future<void> _expandEverySection(WidgetTester tester) async {
+  for (final title in _sectionTitles) {
+    final section = find.ancestor(
+      of: find.text(title),
+      matching: find.byType(SettingsSection),
+    );
+    final collapsed =
+        find.descendant(of: section, matching: find.byIcon(Icons.expand_more));
+    if (collapsed.evaluate().isEmpty) continue;
+
+    await tester.ensureVisible(find.text(title));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(title));
+    await tester.pumpAndSettle();
+  }
+}
+
+Widget _panel() {
+  return MaterialApp(
+    home: Scaffold(
+      body: SettingsPanel(
+        settings: const PlaygroundSettings(),
+        performanceMetrics: PerformanceMetrics(
+          rowCount: 0,
+          lastUpdate: DateTime.fromMillisecondsSinceEpoch(0),
+        ),
+        onSettingsChanged: (_) {},
+        onGenerateData: () {},
+      ),
+    ),
+  );
+}
+
+List<String> _renderedIds(WidgetTester tester) => tester
+    .widgetList<SettingsControl>(find.byType(SettingsControl))
+    .map((c) => c.id)
+    .toList();
+
+/// The `final` fields declared on [PlaygroundSettings], read from its source.
+Set<String> _settingsFields() {
+  final source = File(
+    'lib/pages/playground/models/playground_settings.dart',
+  ).readAsStringSync();
+  final body = source.substring(source.indexOf('class PlaygroundSettings'));
+  return RegExp(r'^  final [\w<>?,\s]+ (\w+);', multiLine: true)
+      .allMatches(body)
+      .map((m) => m.group(1)!)
+      .toSet();
+}
+
+void main() {
+  testWidgets('every control carries a distinct id', (tester) async {
+    await tester.pumpWidget(_panel());
+    await _expandEverySection(tester);
+
+    final ids = _renderedIds(tester);
+    expect(ids, isNotEmpty);
+    expect(ids.where((id) => id.isEmpty), isEmpty, reason: 'no blank ids');
+    expect(ids.toSet().length, ids.length, reason: 'ids are unique');
+  });
+
+  testWidgets('every id names a field of PlaygroundSettings', (tester) async {
+    await tester.pumpWidget(_panel());
+    await _expandEverySection(tester);
+
+    final fields = _settingsFields();
+    expect(fields, hasLength(58),
+        reason: 'the source reader still finds the fields it used to');
+
+    expect(_renderedIds(tester).toSet().difference(fields), isEmpty,
+        reason: 'an id that names nothing is a typo waiting to be believed');
+  });
+}


### PR DESCRIPTION
Closes #72

A label is prose. It repeats across sections, and it is the first thing a redesign rewrites. Anything that wants to reason about a control — which feature owns it, what it depends on, which preset turns it on — cannot hold onto that.

Each of the panel's 58 controls now names the settings field it edits. Nothing renders differently; nothing new is shown. This is the handle #73 and everything after it hold.

## The compiler cannot check an id, so the test reads the source

Dart has no reflection, so "this id names a real field" is not a question the compiler can answer. The test asks the source instead: it reads the settings class, pulls its 58 field names, and fails on an id that names none of them.

Two tests, biting for two different reasons — a duplicated id fails the first, a misspelled one (`sortingEnabledd`) fails the second. Both were checked by breaking them.

An `enum SettingId` was considered and rejected. It would still be a human's job to keep each enum value's name equal to its field's, and checking *that* means reading the source anyway. The enum would have offered the appearance of safety while hiding the same problem one layer down.

## 58 was measured, not assumed

Adding a required id produced exactly 58 compile errors, one per call site. Separately, every one of the 58 settings fields is the target of exactly one control's `copyWith`.

That second fact took three attempts. `grep -c` counts matching *lines*, not matches, and reported 46. A regex whose terminator was too narrow captured 32 of 58 call sites and produced a confident list of "26 fields with no control" — including `tooltipAnchor`, which plainly has one. Each matcher was caught by validating it against fields already known to have controls before believing its answer.

## Verification

`cd example && flutter test` passes (30 tests: 28 existing, 2 new), the package's 378 are untouched and green, `flutter analyze` is clean in both, `dart format` leaves both unchanged. The characterisation test counts the same 25 switches, 12 dropdowns and 21 sliders — the evidence this move changed nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)