### PR TITLE
Describe the playground's settings as data, and test the description

### DIFF
--- a/example/lib/pages/playground/models/settings_spec.dart
+++ b/example/lib/pages/playground/models/settings_spec.dart
@@ -1,0 +1,315 @@
+/// A description of the playground's settings: what owns what, and what
+/// changes what.
+///
+/// The settings themselves stay a flat value class. This is the map beside it,
+/// and `test/settings_spec_test.dart` is what keeps the map honest — a field
+/// left undescribed, or an id naming nothing, turns the suite red. A map
+/// written in prose would be stale within a month.
+library;
+
+/// One thing a reader might be trying to do.
+///
+/// Groups are cut by intent, not by what a setting configures. A feature's own
+/// options do not share an effect — `tooltipBehavior` builds a column while
+/// `tooltipDirection` builds a theme — so cutting by effect would tear the
+/// tooltip feature in half and hide half of it from anyone looking for it.
+class SettingGroup {
+  const SettingGroup({
+    required this.id,
+    required this.title,
+    required this.features,
+  });
+
+  final String id;
+  final String title;
+  final List<SettingFeature> features;
+}
+
+/// A capability of the table, and the settings that only mean something once it
+/// is on.
+///
+/// [switchId] names the boolean field that turns it on, when there is one; a
+/// feature without a switch is a heading over settings that are always live.
+/// The hierarchy *is* the dependency — an option is reachable exactly when the
+/// feature holding it is on — so there is no separate `dependsOn` to drift out
+/// of step with it.
+class SettingFeature {
+  const SettingFeature({
+    required this.id,
+    required this.title,
+    this.switchId,
+    this.options = const [],
+    this.interactions = const [],
+  });
+
+  final String id;
+  final String title;
+
+  /// The settings field that enables this feature, or null when it is always on.
+  final String? switchId;
+
+  /// Settings fields that are only meaningful while this feature is enabled.
+  final List<String> options;
+
+  /// Other features whose behaviour this one changes, or which change it.
+  final List<Interaction> interactions;
+}
+
+/// One feature changing another, and the evidence that it does.
+///
+/// A test can insist that [evidence] is present. It cannot read the code the
+/// citation points at and confirm that [effect] is what happens there — that is
+/// a reviewer's job. So the rule is narrow and enforceable: no interaction is
+/// asserted without a citation.
+class Interaction {
+  const Interaction({
+    required this.otherFeatureId,
+    required this.effect,
+    required this.evidence,
+  });
+
+  final String otherFeatureId;
+
+  /// What actually happens, in the direction it happens.
+  final String effect;
+
+  /// Where in the library, its tests, or the changelog this is established.
+  final String evidence;
+}
+
+const settingsSpec = <SettingGroup>[
+  SettingGroup(
+    id: 'data',
+    title: 'Data',
+    features: [
+      SettingFeature(
+        id: 'data',
+        title: 'Rows',
+        options: ['rowCount'],
+      ),
+    ],
+  ),
+  SettingGroup(
+    id: 'interaction',
+    title: 'Interaction',
+    features: [
+      SettingFeature(
+        id: 'sorting',
+        title: 'Sorting',
+        switchId: 'sortingEnabled',
+        options: ['sortCycleOrder'],
+      ),
+      SettingFeature(
+        id: 'selection',
+        title: 'Selection',
+        switchId: 'selectionEnabled',
+        options: [
+          'selectionMode',
+          'showCheckboxColumn',
+          'selectAllEnabled',
+          'showRowCheckbox',
+          'cellTapTogglesCheckbox',
+        ],
+        interactions: [
+          Interaction(
+            otherFeatureId: 'editing',
+            effect: 'While editing is on, tapping an editable column edits the '
+                'cell and tapping anywhere else selects the row. The cell wins '
+                'the gesture arena; the row does not.',
+            evidence: 'CHANGELOG 2.14.0, BEHAVIOR: "Tapping a row now selects '
+                'it while isEditable is true"',
+          ),
+          Interaction(
+            otherFeatureId: 'mergedRows',
+            effect: 'A merged group is selected as one unit, not as the rows '
+                'it stands for.',
+            evidence: 'row_lookup.dart derives idToGroup from mergedGroups; '
+                'CLAUDE.md, "Merged row groups are treated as single units for '
+                'selection and editing operations"',
+          ),
+        ],
+      ),
+      SettingFeature(
+        id: 'dragSelection',
+        title: 'Drag selection',
+        switchId: 'dragSelectionEnabled',
+        interactions: [
+          Interaction(
+            otherFeatureId: 'selection',
+            effect: 'Dragging only selects while selection is enabled; the '
+                'range it reports is a set of row ids.',
+            evidence: 'The drag selection control lives under the selection '
+                'toggle in the panel, guarded on selectionEnabled',
+          ),
+          Interaction(
+            otherFeatureId: 'mergedRows',
+            effect: 'A drag crossing a merged group adds the group id, not the '
+                'ids of the rows inside it.',
+            evidence:
+                'test/drag_selection_test.dart, "dragging across a merged '
+                'group adds the group ID, not individual rows"; RowGeometry '
+                'snapshots "row id or merged group id"',
+          ),
+        ],
+      ),
+      SettingFeature(
+        id: 'editing',
+        title: 'Cell editing',
+        switchId: 'editingEnabled',
+      ),
+      SettingFeature(
+        id: 'columnReorder',
+        title: 'Column reorder',
+        switchId: 'columnReorderEnabled',
+      ),
+      SettingFeature(
+        id: 'resizing',
+        title: 'Column resizing',
+        switchId: 'resizableEnabled',
+        options: [
+          'columnMinWidth',
+          'stretchLastColumn',
+          'resizeHandleWidth',
+          'resizeHandleThickness',
+          'resizeHandleIndent',
+          'resizeHandleEndIndent',
+        ],
+        interactions: [
+          Interaction(
+            otherFeatureId: 'zoom',
+            effect: 'Resized widths are stored unscaled, so they survive a '
+                'change of zoom and are reported back in logical pixels.',
+            evidence: 'CHANGELOG 2.9.0: "Resized column widths are stored in '
+                'logical (unscaled) units"',
+          ),
+        ],
+      ),
+      SettingFeature(
+        id: 'zoom',
+        title: 'Zoom',
+        options: ['scale', 'blockModifierScroll'],
+      ),
+    ],
+  ),
+  SettingGroup(
+    id: 'content',
+    title: 'Content',
+    features: [
+      SettingFeature(
+        id: 'tooltips',
+        title: 'Tooltips',
+        switchId: 'tooltipEnabled',
+        options: [
+          'tooltipBehavior',
+          'headerTooltipBehavior',
+          'tooltipWaitDurationMs',
+          'tooltipDirection',
+          'tooltipAnchor',
+          'headerTooltipAnchor',
+          'tooltipAlignment',
+          'tooltipShowArrow',
+          'tooltipOffset',
+          'showTooltipFormatter',
+          'showTooltipBuilder',
+        ],
+        interactions: [
+          Interaction(
+            otherFeatureId: 'rowCard',
+            effect: 'Turning tooltips off silences the row card too. And with '
+                'TooltipBehavior.always every ellipsized column already has a '
+                'tooltip, which leaves the card nowhere to appear.',
+            evidence: 'test/row_tooltip_test.dart, "TooltipBehavior.always '
+                'leaves no room for the card"; CHANGELOG 2.14.0',
+          ),
+        ],
+      ),
+      SettingFeature(
+        id: 'rowCard',
+        title: 'Row card',
+        switchId: 'rowCardTooltip',
+        options: ['rowCardWaitDurationMs'],
+        interactions: [
+          Interaction(
+            otherFeatureId: 'mergedRows',
+            effect: 'A merged row carries no card. It stands for several data '
+                'rows, so there is no single one to build the card from.',
+            evidence: 'table_body.dart returns the row unwrapped when '
+                '_getMergedGroupForRow is non-null; test/row_tooltip_test.dart, '
+                '"a merged row carries no card"',
+          ),
+        ],
+      ),
+      SettingFeature(
+        id: 'mergedRows',
+        title: 'Merged rows',
+        switchId: 'mergedRowsEnabled',
+      ),
+      SettingFeature(
+        id: 'dynamicRowHeight',
+        title: 'Dynamic row heights',
+        switchId: 'dynamicRowHeight',
+      ),
+      SettingFeature(
+        id: 'dimRows',
+        title: 'Dimmed rows',
+        switchId: 'dimInactiveRows',
+      ),
+    ],
+  ),
+  SettingGroup(
+    id: 'appearance',
+    title: 'Appearance',
+    features: [
+      SettingFeature(
+        id: 'rowStyle',
+        title: 'Rows and text',
+        options: [
+          'rowHeight',
+          'fontSize',
+          'fontFamily',
+          'horizontalPadding',
+          'verticalPadding',
+          'sortIconWidth',
+          'checkboxTapTargetSize',
+        ],
+      ),
+      SettingFeature(
+        id: 'alternateRows',
+        title: 'Alternating row colour',
+        switchId: 'showAlternateRows',
+      ),
+      SettingFeature(
+        id: 'bodyDividers',
+        title: 'Body dividers',
+        switchId: 'showDividers',
+      ),
+      SettingFeature(
+        id: 'ink',
+        title: 'Row ink',
+        options: ['splashColor', 'hoverColor', 'highlightColor'],
+      ),
+      SettingFeature(
+        id: 'headerTopBorder',
+        title: 'Header top border',
+        switchId: 'headerTopBorderShow',
+        options: ['headerTopBorderThickness'],
+      ),
+      SettingFeature(
+        id: 'headerBottomBorder',
+        title: 'Header bottom border',
+        switchId: 'headerBottomBorderShow',
+        options: ['headerBottomBorderThickness'],
+      ),
+      SettingFeature(
+        id: 'headerVerticalDivider',
+        title: 'Header vertical divider',
+        switchId: 'headerVerticalDividerShow',
+        options: [
+          'headerVerticalDividerThickness',
+          'headerVerticalDividerIndent',
+          'headerVerticalDividerEndIndent',
+        ],
+      ),
+    ],
+  ),
+];

--- a/example/test/settings_spec_test.dart
+++ b/example/test/settings_spec_test.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:example/pages/playground/models/settings_spec.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// The description of the playground's settings is data, and these tests are
+// what keep it true. A map written in prose would be stale within a month; this
+// one goes red the moment it stops matching the class it describes.
+//
+// What a machine can check: that every field is described exactly once, that
+// every id points at something, that no interaction is asserted without a
+// citation. What it cannot check is whether the citation *says* what the
+// interaction claims. That is a reviewer's job, and #76 says so.
+
+/// The `final` fields declared on `PlaygroundSettings`, read from its source.
+///
+/// Dart has no reflection, so this question cannot be put to the compiler.
+Set<String> _settingsFields() {
+  final source = File(
+    'lib/pages/playground/models/playground_settings.dart',
+  ).readAsStringSync();
+  final body = source.substring(source.indexOf('class PlaygroundSettings'));
+  return RegExp(r'^  final [\w<>?,\s]+ (\w+);', multiLine: true)
+      .allMatches(body)
+      .map((m) => m.group(1)!)
+      .toSet();
+}
+
+Iterable<SettingFeature> get _features =>
+    settingsSpec.expand((group) => group.features);
+
+/// Every id the spec claims is a settings field: a feature's own switch, and
+/// the options that only mean something once that switch is on.
+List<String> _describedFields() => [
+      for (final f in _features) ...[
+        if (f.switchId != null) f.switchId!,
+        ...f.options,
+      ],
+    ];
+
+void main() {
+  test('the spec describes every settings field exactly once', () {
+    final described = _describedFields();
+    final fields = _settingsFields();
+
+    expect(fields, hasLength(58),
+        reason: 'the source reader still finds the fields it used to');
+
+    final duplicated =
+        described.where((id) => described.where((o) => o == id).length > 1);
+    expect(duplicated, isEmpty, reason: 'a field described twice');
+
+    expect(described.toSet().difference(fields), isEmpty,
+        reason: 'the spec describes a field that does not exist');
+    expect(fields.difference(described.toSet()), isEmpty,
+        reason: 'a field nobody described — add it to the spec');
+  });
+
+  test('every interaction names a feature that exists', () {
+    final featureIds = _features.map((f) => f.id).toSet();
+
+    for (final f in _features) {
+      for (final i in f.interactions) {
+        expect(featureIds, contains(i.otherFeatureId),
+            reason: '${f.id} claims to interact with ${i.otherFeatureId}');
+        expect(i.otherFeatureId, isNot(f.id),
+            reason: '${f.id} interacts with itself');
+      }
+    }
+  });
+
+  test('no interaction is asserted without a citation', () {
+    for (final f in _features) {
+      for (final i in f.interactions) {
+        expect(i.effect.trim(), isNotEmpty, reason: '${f.id} → what happens?');
+        expect(i.evidence.trim(), isNotEmpty,
+            reason: '${f.id} → ${i.otherFeatureId} cites nothing');
+      }
+    }
+  });
+
+  test('feature and group ids are unique', () {
+    final groupIds = settingsSpec.map((g) => g.id).toList();
+    expect(groupIds.toSet().length, groupIds.length);
+
+    final featureIds = _features.map((f) => f.id).toList();
+    expect(featureIds.toSet().length, featureIds.length);
+  });
+}


### PR DESCRIPTION
Closes #73

Sixty settings, and the only record of how they relate was eight `if` guards inside widget code. The other fifty-two fields had no relationship written down anywhere. The coupling *between* features — a merged row carries no card, a drag across a merged group reports the group id, turning tooltips off silences the card — lived scattered across library source, its tests, and this repo's changelog.

It is data now: four groups of twenty features, sixteen of which own a switch, holding forty-two options between them. Sixteen plus forty-two is fifty-eight, which is every field.

**Nothing renders from it yet.** The panel is untouched; #74 is where this becomes visible. What ships here is the description and the tests that keep it true.

## The hierarchy is the dependency

An option is reachable exactly when the feature holding it is on. There is no separate `dependsOn` to drift out of step with the tree that already says the same thing.

## Four invariants, each checked by breaking it

Every field described exactly once. Every id naming a feature that exists. No feature interacting with itself. No interaction asserted without a citation.

Each break failed its own test: a missing field and a duplicated one both fail the coverage test, a misspelled feature id fails the reference test, a blank citation fails the citation test. All four passed on the first run, which is precisely when a test deserves to be doubted.

A test can insist a citation is present. It cannot read the code the citation points at and confirm the claim. That line is drawn on purpose, and said so in the source: seven interactions are recorded, each citing library source, a test, or a changelog entry, and #76 makes verifying them a reviewer's job.

## The issue's premise was wrong, and the spec is what showed it

#73 said to cut groups by effect — theme, behaviour, columns — citing a measurement that was itself correct: 35 settings feed the theme, 16 the widget, 5 the columns.

But a feature's own options do not share an effect. `tooltipEnabled` owns `tooltipBehavior`, which configures a column, and `tooltipDirection`, which configures a theme. Cut by effect and the tooltip feature is torn in half, with a reader finding half the answer under Columns and half under Appearance.

That a set of data *has* a structure does not make that structure *useful*. Where a setting flows is the library's concern; what a reader is trying to do is the panel's. Groups are cut by intent — Data, Interaction, Content, Appearance — and #73 is corrected with the reasoning recorded on it.

## Verification

`cd example && flutter test` passes (34 tests: 30 existing, 4 new), the package's 378 are untouched and green, `flutter analyze` is clean in both, `dart format` leaves both unchanged. The existing suite is unmodified, which is what "nothing renders from it yet" means.

🤖 Generated with [Claude Code](https://claude.com/claude-code)