### PR TITLE
A search finds a setting its feature has switched off

### DIFF
--- a/example/lib/pages/playground/widgets/settings_panel.dart
+++ b/example/lib/pages/playground/widgets/settings_panel.dart
@@ -115,17 +115,21 @@ class _SettingsPanelState extends State<SettingsPanel> {
       borderColor: _groupBorders[group.id]!,
       initiallyExpanded: group.id == 'data',
       children: [
-        for (final feature in group.features) ..._buildFeature(feature),
+        for (final feature in group.features) ..._buildFeature(feature, query),
       ],
     );
   }
 
-  /// A feature's switch, then the options it owns — which only appear while it
-  /// is on. Eight of these were guarded by hand; the description knows all of
-  /// them.
-  List<Widget> _buildFeature(SettingFeature feature) {
+  /// A feature's switch, then the options it owns.
+  ///
+  /// An option means nothing while its feature is off, so it is not there —
+  /// until someone searches for it. A search that turns up nothing cannot say
+  /// whether the setting does not exist or merely cannot be used, so a search
+  /// surfaces it, unavailable, naming the feature that would enable it.
+  List<Widget> _buildFeature(SettingFeature feature, String query) {
     final s = widget.settings;
     final on = feature.switchId == null || _isOn(feature.switchId!);
+    final searching = query.trim().isNotEmpty;
 
     return [
       if (feature.switchId != null) _draw(feature.switchId!),
@@ -133,9 +137,42 @@ class _SettingsPanelState extends State<SettingsPanel> {
       if (on) ...[
         for (final option in feature.options) _draw(option),
         if (feature.id == 'data') ..._dataExtras(s),
-      ],
+      ] else if (searching)
+        for (final option in feature.options) _drawUnavailable(option, feature),
       const SizedBox(height: 8),
     ];
+  }
+
+  /// The control as the search found it: readable, unreachable, and saying what
+  /// would make it reachable.
+  ///
+  /// It stays a [SettingsControl] so the search still sees a label to match on,
+  /// and the note lives inside it for the same reason.
+  Widget _drawUnavailable(String id, SettingFeature feature) {
+    final control = settingsRegistry[id]!(widget.settings, (_) {});
+    return SettingsControl(
+      id: control.id,
+      label: control.label,
+      indent: control.indent,
+      child: Opacity(
+        opacity: 0.5,
+        child: IgnorePointer(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              control.child,
+              Padding(
+                padding: const EdgeInsets.only(left: 8, bottom: 4),
+                child: Text(
+                  'Turn on ${feature.title} to use this',
+                  style: TextStyle(fontSize: 11, color: Colors.orange.shade800),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 
   Widget _draw(String id) =>

--- a/example/test/settings_gating_test.dart
+++ b/example/test/settings_gating_test.dart
@@ -1,0 +1,91 @@
+import 'package:example/pages/playground/models/playground_settings.dart';
+import 'package:example/pages/playground/widgets/performance_monitor.dart';
+import 'package:example/pages/playground/widgets/settings_controls.dart';
+import 'package:example/pages/playground/widgets/settings_panel.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// An option belongs to a feature, and means nothing while that feature is off.
+// So it is not there — until someone searches for it, and then it appears
+// unavailable rather than absent. A search that finds nothing cannot tell you
+// whether the setting does not exist or merely cannot be used.
+//
+// The row card is off by default, and its wait duration is its option. Before
+// the description said so, that slider sat under the tooltip toggle and was
+// adjustable while the card it belonged to was not even drawn.
+
+const _cardWait = 'Row Card Wait';
+const _cardFeature = 'Row card';
+
+Widget _panel(PlaygroundSettings settings) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SettingsPanel(
+        settings: settings,
+        performanceMetrics: PerformanceMetrics(
+          rowCount: 0,
+          lastUpdate: DateTime.fromMillisecondsSinceEpoch(0),
+        ),
+        onSettingsChanged: (_) {},
+        onGenerateData: () {},
+      ),
+    ),
+  );
+}
+
+Future<void> _openContent(WidgetTester tester) async {
+  await tester.ensureVisible(find.text('Content'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Content'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('an option is absent while its feature is off', (tester) async {
+    await tester.pumpWidget(_panel(const PlaygroundSettings()));
+    await _openContent(tester);
+
+    expect(find.text('Row Card Tooltip'), findsOneWidget,
+        reason: 'the feature switch itself is always there');
+    expect(find.text(_cardWait), findsNothing);
+  });
+
+  testWidgets('turning the feature on brings its option back', (tester) async {
+    await tester.pumpWidget(
+      _panel(const PlaygroundSettings(rowCardTooltip: true)),
+    );
+    await _openContent(tester);
+
+    expect(find.text(_cardWait), findsOneWidget);
+  });
+
+  testWidgets('a search finds an option whose feature is off, and says so',
+      (tester) async {
+    await tester.pumpWidget(_panel(const PlaygroundSettings()));
+
+    await tester.enterText(find.byType(TextField), 'row card wait');
+    await tester.pumpAndSettle();
+
+    expect(find.text(_cardWait), findsOneWidget,
+        reason: 'absent is not the same as non-existent');
+    expect(find.textContaining(_cardFeature), findsWidgets,
+        reason: 'the search must say which feature would enable it');
+  });
+
+  testWidgets('an option surfaced by search cannot be changed', (tester) async {
+    await tester.pumpWidget(_panel(const PlaygroundSettings()));
+
+    await tester.enterText(find.byType(TextField), 'row card wait');
+    await tester.pumpAndSettle();
+
+    final control = find.ancestor(
+      of: find.text(_cardWait),
+      matching: find.byType(SettingsControl),
+    );
+    expect(
+      find.descendant(of: control, matching: find.byType(IgnorePointer)),
+      findsWidgets,
+      reason: 'unavailable, not merely styled to look it',
+    );
+  });
+}


### PR DESCRIPTION
Closes #75

Rendering from the description (#74) already did four of this issue's six criteria. Every option became reachable exactly when the feature holding it is on — not just the eight the old code guarded by hand — and the resize handle's appearance went back under the toggle that gives it meaning. What was left was the choice this issue deliberately left open, and the one place that choice pinches.

## Hidden, not dimmed

Always dimming an unavailable option would make the panel longer at exactly the moment it has least to say. The length of this panel is what started the redesign.

## But a search must not answer with silence

A search that finds nothing cannot tell you whether a setting does not exist or merely cannot be used. So a search surfaces it: readable, unreachable, and naming the feature that would enable it.

It stays a `SettingsControl`, because search only matches labelled controls, and the note lives inside it for the same reason — a constraint set when search was built in #62.

The note writes itself from the hierarchy: an option knows which feature holds it, so `Turn on Row card to use this` needs no lookup and no second place for the relationship to be recorded. This is what #73 bought by making the tree *be* the dependency instead of carrying a `dependsOn` beside it.

## Unreachable is IgnorePointer, not opacity

The two new tests hold different lines. Removing the search branch fails both. Removing `IgnorePointer` fails only the one asserting that a surfaced option cannot be changed — because a control that merely looks disabled is a control that can still be dragged.

## Verification

`cd example && flutter test` passes (39 tests: 35 existing, 4 new), the package's 378 are untouched and green, `flutter analyze` is clean in both, `dart format` leaves both unchanged, nothing overflows under the widget-test font. Each new test was checked to fail without its production change. Driven and confirmed on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)