### PR TITLE
Cite the library for drag selection, not the panel

### DIFF
--- a/example/lib/pages/playground/models/settings_spec.dart
+++ b/example/lib/pages/playground/models/settings_spec.dart
@@ -136,10 +136,14 @@ const settingsSpec = <SettingGroup>[
         interactions: [
           Interaction(
             otherFeatureId: 'selection',
-            effect: 'Dragging only selects while selection is enabled; the '
-                'range it reports is a set of row ids.',
-            evidence: 'The drag selection control lives under the selection '
-                'toggle in the panel, guarded on selectionEnabled',
+            effect: 'Dragging selects nothing while selection is off. The '
+                'table requires both.',
+            // Cite the library, not the panel. The panel's shape is ours to
+            // change, and citing it went stale the moment the sections that
+            // guarded this control were deleted.
+            evidence: 'flutter_table_plus.dart: _isDragSelectionEnabled is '
+                'enableDragSelection && isSelectable && '
+                'onDragSelectionUpdate != null',
           ),
           Interaction(
             otherFeatureId: 'mergedRows',


### PR DESCRIPTION
The settings description claimed drag selection needs selection on, and cited the panel: *"the drag selection control lives under the selection toggle, guarded on `selectionEnabled`"*. That was true while five hand-written sections nested it there. #74 deleted those sections, and the citation went false the same day it was written.

The claim holds — `_isDragSelectionEnabled` is `enableDragSelection && isSelectable && onDragSelectionUpdate != null` — so the evidence now points at that, and at nothing the panel is free to rearrange.

**No test caught this, and none could.** The invariant a machine can enforce is that a citation exists, not that it is true. The source says so, and #76 makes verifying them a reviewer's job. This is that job, done once.

The lesson is narrower than "documentation rots": cite the thing that cannot be refactored out from under you. A library's control flow is such a thing. A panel's layout is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)