### PR TITLE
docs(tooltip): say where the row card's hover region ends, and what displaces it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 *   **FIX**: a cell whose `tooltipFormatter` returns an empty string no longer swallows the `rowTooltipBuilder` card. Hovering such a cell showed nothing at all — not the cell's tooltip, not the row's
     *   A tooltip suppresses its ancestors from `MouseRegion.onEnter`, *before* it decides whether it has anything to draw, and `hideOnEmptyMessage` decides "nothing" inside `_show()`. The cell had already taken the card down. Hoisting that guard to where the cell is wrapped means a tooltip that cannot show is never built, so it cannot suppress anything. The header has guarded this way all along — an empty label gets no tooltip — but a cell's message is only known once `tooltipFormatter` has run
     *   `hideOnEmptyMessage: false` is unchanged: that asks for the empty bubble, and it still wins over the card
-*   **DOCS**: `rowTooltipBuilder`'s "the whole row is the hover region" is now pinned by tests, including over a cell whose value is empty. It was never broken there — a row's `MouseRegion` is opaque and hit-tests itself, so a zero-width `Text` under the pointer changes nothing — but nothing said so, and the neighbouring `tooltipFormatter` bug looked exactly like a hole in that region
+*   **DOCS**: `rowTooltipBuilder`'s "the whole row is the hover region" is now pinned by tests, including over a cell whose value is empty. It was never broken there — a row's `MouseRegion` is opaque and hit-tests itself, so a zero-width `Text` under the pointer changes nothing — but nothing said so, and the neighbouring `tooltipFormatter` bug looked exactly like a hole in that region. The doc comment now says which boundaries the region actually has, and which cells take the card's place
+*   **DOCS**: `TablePlusTooltipTheme.hideOnEmptyMessage` was absent from `docs/THEMING.md` altogether. It was a footnote when a tooltip stood alone; it decides whether the row card appears once one nests inside another
 
 ## 2.15.1
 

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -373,6 +373,7 @@ TablePlusTooltipTheme(
   enableHover: true,
   enableTap: false,
   interactive: true,
+  hideOnEmptyMessage: true,             // an empty message builds no tooltip at all
 
   // Animation
   animation: TooltipAnimation.fade,     // none, fade, scale, slide, fadeScale, fadeSlide, rotation
@@ -413,6 +414,19 @@ Row tooltips built by `rowTooltipBuilder` always anchor at the pointer and
 ignore this field. A row is as wide as the table's content, so a child anchor
 would aim at the centre of whatever slice of the row is on screen — visible, but
 unrelated to where along the row you are pointing.
+
+### Empty messages
+
+`hideOnEmptyMessage` (default `true`) means a tooltip whose message resolves to
+an empty string is **not built at all**, rather than built and hidden. The two
+differ once tooltips nest. A tooltip suppresses the ones around it the moment
+the pointer enters it — so a cell tooltip that were built and then declined to
+draw would take a `rowTooltipBuilder` card down with it, and the cell would show
+nothing at all. Not building it leaves the card intact.
+
+Set it to `false` and the empty bubble is drawn, and suppresses the card the way
+any other cell tooltip does. `tooltipBuilder` content is not a message, so the
+flag does not apply to it.
 
 ---
 

--- a/lib/src/widgets/flutter_table_plus.dart
+++ b/lib/src/widgets/flutter_table_plus.dart
@@ -156,13 +156,24 @@ class FlutterTablePlus<T> extends StatefulWidget {
   /// Builds a rich tooltip card shown while the pointer is anywhere on the row.
   ///
   /// Return null for a row that should not have one. The whole row is the hover
-  /// region, and the card is anchored beside the pointer.
+  /// region, and the card is anchored beside the pointer. "Whole" is literal:
+  /// the blank space past the last column, and a cell whose value is empty,
+  /// both show the card. (An empty cell paints a zero-width `Text`, but the
+  /// row's `MouseRegion` is opaque and hit-tests itself, so nothing needs to
+  /// be under the pointer for the row to be hovered.)
   ///
   /// A cell with a tooltip of its own wins: exactly one tooltip is visible, the
   /// innermost under the pointer. Note that `TooltipBehavior.always` — the
   /// default — gives *every* ellipsized text column a tooltip whether or not
   /// its text is actually cut, which leaves the card nowhere to appear. Use
   /// [TooltipBehavior.onlyTextOverflow] on text columns alongside a row card.
+  ///
+  /// A cell only takes the card's place when it has something to show. A
+  /// [TablePlusColumn.tooltipFormatter] returning an empty string yields no
+  /// cell tooltip, so the card surfaces there — unless
+  /// [TablePlusTooltipTheme.hideOnEmptyMessage] is false, which asks for the
+  /// empty bubble. A [TablePlusColumn.tooltipBuilder] is always taken to have
+  /// content and always wins, even if the widget it returns draws nothing.
   ///
   /// Merged rows stand for several data rows and never show a card.
   ///


### PR DESCRIPTION
Refs #88. Doc-only follow-up to #89 — the sweep that PR should have carried.

## Two gaps

**1. `rowTooltipBuilder`'s doc named the promise but not its boundaries.**

> Return null for a row that should not have one. The whole row is the hover region, and the card is anchored beside the pointer.

True, and unhelpful at exactly the point where a reader doubts it. An empty cell paints a zero-width `Text`, so "the whole row" invites the guess that the row cannot be hovered there. It can — the row's `MouseRegion` is opaque and hit-tests itself — but nothing said which reading was right. The bug fixed in #89 produced precisely the symptom that wrong reading predicts, which is how it got misdiagnosed in the first place.

The doc now says the blank space past the last column and an empty-valued cell both show the card, why, and which cells displace it: a `tooltipFormatter` returning `''` does not, a `tooltipBuilder` always does.

**2. `hideOnEmptyMessage` was absent from `docs/THEMING.md`.**

Not under-explained — absent, while every other `TablePlusTooltipTheme` field is listed. That was fair when a tooltip stood alone: "empty message, no tooltip" needs no essay. Once tooltips nest it decides whether the row card appears, because a built-then-hidden tooltip suppresses its ancestors and a never-built one does not. Now listed, with that consequence.

## Verified, not assumed

The same doc calls `TooltipBehavior.always` "the default". It is — `table_column.dart:109`. Left as written.

`CHANGELOG.md`'s `2.15.2` section is amended in place: `curl /api/packages/flutter_table_plus/versions/2.15.2` -> 404 (control `9.9.9` -> 404), so it is unpublished and not yet frozen.

## Gates

```
flutter analyze                                     0 issues
dart format --output=none --set-exit-if-changed     clean
flutter test                                        382 passed
flutter pub publish --dry-run                       0 warnings
```

No library behaviour changed; `example/` is untouched, so its suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)