### PR TITLE
Presets, and a playground that opens bare

### DIFF
--- a/example/lib/pages/playground/models/feature_switches.dart
+++ b/example/lib/pages/playground/models/feature_switches.dart
@@ -1,0 +1,85 @@
+import 'playground_settings.dart';
+
+/// Reading and writing a settings field by name.
+///
+/// The description names a feature's switch with a string, and Dart cannot turn
+/// a string into a field. So the knowledge lives here, once, and
+/// `test/settings_presets_test.dart` holds it to the description: every switch
+/// the description declares must appear as a key.
+///
+/// Without that invariant the panel had a quiet default — an unknown switch id
+/// read as `true`, so a feature whose switch nobody taught it to read would be
+/// drawn as permanently on, and nothing would fail.
+class FeatureSwitch {
+  const FeatureSwitch({required this.read, required this.write});
+
+  final bool Function(PlaygroundSettings) read;
+  final PlaygroundSettings Function(PlaygroundSettings, bool) write;
+}
+
+final Map<String, FeatureSwitch> featureSwitches = {
+  'sortingEnabled': FeatureSwitch(
+    read: (s) => s.sortingEnabled,
+    write: (s, v) => s.copyWith(sortingEnabled: v),
+  ),
+  'selectionEnabled': FeatureSwitch(
+    read: (s) => s.selectionEnabled,
+    write: (s, v) => s.copyWith(selectionEnabled: v),
+  ),
+  'dragSelectionEnabled': FeatureSwitch(
+    read: (s) => s.dragSelectionEnabled,
+    write: (s, v) => s.copyWith(dragSelectionEnabled: v),
+  ),
+  'editingEnabled': FeatureSwitch(
+    read: (s) => s.editingEnabled,
+    write: (s, v) => s.copyWith(editingEnabled: v),
+  ),
+  'columnReorderEnabled': FeatureSwitch(
+    read: (s) => s.columnReorderEnabled,
+    write: (s, v) => s.copyWith(columnReorderEnabled: v),
+  ),
+  'resizableEnabled': FeatureSwitch(
+    read: (s) => s.resizableEnabled,
+    write: (s, v) => s.copyWith(resizableEnabled: v),
+  ),
+  'tooltipEnabled': FeatureSwitch(
+    read: (s) => s.tooltipEnabled,
+    write: (s, v) => s.copyWith(tooltipEnabled: v),
+  ),
+  'rowCardTooltip': FeatureSwitch(
+    read: (s) => s.rowCardTooltip,
+    write: (s, v) => s.copyWith(rowCardTooltip: v),
+  ),
+  'mergedRowsEnabled': FeatureSwitch(
+    read: (s) => s.mergedRowsEnabled,
+    write: (s, v) => s.copyWith(mergedRowsEnabled: v),
+  ),
+  'dynamicRowHeight': FeatureSwitch(
+    read: (s) => s.dynamicRowHeight,
+    write: (s, v) => s.copyWith(dynamicRowHeight: v),
+  ),
+  'dimInactiveRows': FeatureSwitch(
+    read: (s) => s.dimInactiveRows,
+    write: (s, v) => s.copyWith(dimInactiveRows: v),
+  ),
+  'showAlternateRows': FeatureSwitch(
+    read: (s) => s.showAlternateRows,
+    write: (s, v) => s.copyWith(showAlternateRows: v),
+  ),
+  'showDividers': FeatureSwitch(
+    read: (s) => s.showDividers,
+    write: (s, v) => s.copyWith(showDividers: v),
+  ),
+  'headerTopBorderShow': FeatureSwitch(
+    read: (s) => s.headerTopBorderShow,
+    write: (s, v) => s.copyWith(headerTopBorderShow: v),
+  ),
+  'headerBottomBorderShow': FeatureSwitch(
+    read: (s) => s.headerBottomBorderShow,
+    write: (s, v) => s.copyWith(headerBottomBorderShow: v),
+  ),
+  'headerVerticalDividerShow': FeatureSwitch(
+    read: (s) => s.headerVerticalDividerShow,
+    write: (s, v) => s.copyWith(headerVerticalDividerShow: v),
+  ),
+};

--- a/example/lib/pages/playground/models/settings_presets.dart
+++ b/example/lib/pages/playground/models/settings_presets.dart
@@ -1,0 +1,85 @@
+import 'feature_switches.dart';
+import 'playground_settings.dart';
+
+/// A named set of features to turn on, and what to watch once they are.
+///
+/// Two of these are structural — a bare table, and everything at once. The rest
+/// are named for the **interaction** they demonstrate, not for the features they
+/// enable: `Selection` and `Editing` are switches the panel already has, and a
+/// preset named after one of them says nothing a switch did not. `Selection +
+/// Editing` earns its name, because it answers whether a tap edits the cell or
+/// selects the row.
+///
+/// A preset that names an interaction must actually produce it. Turning on drag
+/// selection over data with no merged group demonstrates nothing, so
+/// `dragOverMergedRows` names all three features the interaction needs.
+class SettingsPreset {
+  const SettingsPreset({
+    required this.id,
+    required this.title,
+    required this.lookFor,
+    required this.featuresOn,
+  });
+
+  final String id;
+  final String title;
+
+  /// What to watch for once the preset is applied.
+  final String lookFor;
+
+  /// The switch ids to turn on. Everything else is turned off.
+  final Set<String> featuresOn;
+}
+
+/// `bare` is first because the playground opens on it: an addition needs a zero
+/// to be measured against, and the row count is not what makes a table bare —
+/// a table with no scroll cannot show drag selection or auto-scroll.
+final List<SettingsPreset> presets = [
+  SettingsPreset(
+    id: 'bare',
+    title: 'Bare',
+    lookFor: 'A plain table. Nothing is on. Add one thing at a time and watch '
+        'what it changes.',
+    featuresOn: const {},
+  ),
+  SettingsPreset(
+    id: 'everything',
+    title: 'Everything',
+    lookFor: 'Every feature at once. This is where tables break — on '
+        'combinations, not on any single feature.',
+    featuresOn: featureSwitches.keys.toSet(),
+  ),
+  SettingsPreset(
+    id: 'selectionAndEditing',
+    title: 'Selection + Editing',
+    lookFor: 'Tap an editable column and the cell edits. Tap anywhere else on '
+        'the row and it selects. The cell wins the gesture arena.',
+    featuresOn: const {'selectionEnabled', 'editingEnabled'},
+  ),
+  SettingsPreset(
+    id: 'dragOverMergedRows',
+    title: 'Drag select over merged rows',
+    lookFor: 'Drag across a merged group. One group id arrives, not the ids of '
+        'the rows inside it.',
+    featuresOn: const {
+      'selectionEnabled',
+      'dragSelectionEnabled',
+      'mergedRowsEnabled',
+    },
+  ),
+];
+
+SettingsPreset presetById(String id) => presets.firstWhere((p) => p.id == id);
+
+/// Turns on exactly the features [preset] names, and turns off every other one.
+///
+/// Settings that are not feature switches — the row count, a slider's value —
+/// are left as they were. A preset chooses which features are on, not what they
+/// are configured to do.
+PlaygroundSettings applyPreset(PlaygroundSettings base, SettingsPreset preset) {
+  var result = base;
+  for (final entry in featureSwitches.entries) {
+    result = entry.value.write(result, preset.featuresOn.contains(entry.key));
+  }
+  return result;
+}

--- a/example/lib/pages/playground/playground_page.dart
+++ b/example/lib/pages/playground/playground_page.dart
@@ -7,10 +7,12 @@ import 'package:google_fonts/google_fonts.dart';
 
 import 'models/employee.dart';
 import 'models/playground_settings.dart';
+import 'models/settings_presets.dart';
 import 'playground_columns.dart';
 import 'playground_format.dart';
 import 'utils/random_data_generator.dart';
 import 'widgets/performance_monitor.dart';
+import 'widgets/preset_bar.dart';
 import 'widgets/settings_panel.dart';
 
 /// Interactive playground for testing FlutterTablePlus
@@ -29,7 +31,15 @@ class PlaygroundPage extends StatefulWidget {
 
 class _PlaygroundPageState extends State<PlaygroundPage> {
   // Settings
-  PlaygroundSettings _settings = const PlaygroundSettings();
+  /// The playground opens bare: an addition needs a zero to be measured
+  /// against. The row count is left alone — a table with no scroll cannot show
+  /// drag selection or auto-scroll.
+  PlaygroundSettings _settings =
+      applyPreset(const PlaygroundSettings(), presetById('bare'));
+
+  /// The preset whose state the settings still match, or null once the reader
+  /// has changed something by hand.
+  String? _activePresetId = 'bare';
 
   // Data
   List<Employee> _data = [];
@@ -144,7 +154,13 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
   }
 
   /// Handle settings changes
+  void _applyPreset(SettingsPreset preset) {
+    _handleSettingsChanged(applyPreset(_settings, preset));
+    setState(() => _activePresetId = preset.id);
+  }
+
   void _handleSettingsChanged(PlaygroundSettings newSettings) {
+    _activePresetId = null;
     setState(() {
       final oldSettings = _settings;
       _settings = newSettings;
@@ -595,43 +611,53 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
             ),
         ],
       ),
-      body: Row(
+      body: Column(
         children: [
-          // Left: Settings Panel
-          SettingsPanel(
-            settings: _settings,
-            performanceMetrics: _performanceMetrics,
-            onSettingsChanged: _handleSettingsChanged,
-            onGenerateData: _generateData,
-            onRandomizeWidths: _randomizeColumnWidths,
-            onRandomSavedWidths: () {
-              final rng = Random();
-              setState(() {
-                _activeInitialWidths = {
-                  for (final entry in _columns.entries)
-                    entry.key: (entry.value.minWidth +
-                            rng.nextDouble() *
-                                ((entry.value.maxWidth ?? 400.0) -
-                                    entry.value.minWidth))
-                        .roundToDouble(),
-                };
-              });
-              debugPrint('🎲 Applied random widths (not saved)');
-            },
-            onRestoreWidths: () {
-              setState(() {
-                _activeInitialWidths = Map.of(_savedWidths);
-              });
-              debugPrint(
-                  '♻️ Restored saved widths: ${_savedWidths.entries.map((e) => '${e.key}: ${e.value.toStringAsFixed(1)}px').join(', ')}');
-            },
-            hasSavedWidths: _savedWidths.isNotEmpty,
-            isGenerating: _isGenerating,
+          PresetBar(
+            activePresetId: _activePresetId,
+            onPresetSelected: _applyPreset,
           ),
-
-          // Right: Table Area
           Expanded(
-            child: _buildTableArea(),
+            child: Row(
+              children: [
+                // Left: Settings Panel
+                SettingsPanel(
+                  settings: _settings,
+                  performanceMetrics: _performanceMetrics,
+                  onSettingsChanged: _handleSettingsChanged,
+                  onGenerateData: _generateData,
+                  onRandomizeWidths: _randomizeColumnWidths,
+                  onRandomSavedWidths: () {
+                    final rng = Random();
+                    setState(() {
+                      _activeInitialWidths = {
+                        for (final entry in _columns.entries)
+                          entry.key: (entry.value.minWidth +
+                                  rng.nextDouble() *
+                                      ((entry.value.maxWidth ?? 400.0) -
+                                          entry.value.minWidth))
+                              .roundToDouble(),
+                      };
+                    });
+                    debugPrint('🎲 Applied random widths (not saved)');
+                  },
+                  onRestoreWidths: () {
+                    setState(() {
+                      _activeInitialWidths = Map.of(_savedWidths);
+                    });
+                    debugPrint(
+                        '♻️ Restored saved widths: ${_savedWidths.entries.map((e) => '${e.key}: ${e.value.toStringAsFixed(1)}px').join(', ')}');
+                  },
+                  hasSavedWidths: _savedWidths.isNotEmpty,
+                  isGenerating: _isGenerating,
+                ),
+
+                // Right: Table Area
+                Expanded(
+                  child: _buildTableArea(),
+                ),
+              ],
+            ),
           ),
         ],
       ),

--- a/example/lib/pages/playground/widgets/preset_bar.dart
+++ b/example/lib/pages/playground/widgets/preset_bar.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import '../models/settings_presets.dart';
+
+/// The named combinations, above the table.
+///
+/// A preset is the first thing anyone will feel, which is why it arrived before
+/// the panel was rebuilt: a set of feature switches applied to the settings,
+/// and `copyWith` was always enough for that.
+class PresetBar extends StatelessWidget {
+  const PresetBar({
+    super.key,
+    required this.activePresetId,
+    required this.onPresetSelected,
+  });
+
+  final String? activePresetId;
+  final ValueChanged<SettingsPreset> onPresetSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final active = activePresetId == null ? null : presetById(activePresetId!);
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(20, 12, 20, 12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border(bottom: BorderSide(color: Colors.grey.shade300)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              for (final preset in presets)
+                ChoiceChip(
+                  label: Text(preset.title),
+                  selected: preset.id == activePresetId,
+                  onSelected: (picked) =>
+                      picked ? onPresetSelected(preset) : null,
+                ),
+            ],
+          ),
+          if (active != null) ...[
+            const SizedBox(height: 8),
+            // The line that makes a preset worth its name: not which features
+            // it turned on, but what to watch now that they are.
+            Text(
+              active.lookFor,
+              style: TextStyle(fontSize: 12, color: Colors.grey.shade700),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/pages/playground/widgets/settings_panel.dart
+++ b/example/lib/pages/playground/widgets/settings_panel.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../models/feature_switches.dart';
 import '../models/playground_settings.dart';
 import '../models/settings_spec.dart';
 import 'performance_monitor.dart';
@@ -178,26 +179,13 @@ class _SettingsPanelState extends State<SettingsPanel> {
   Widget _draw(String id) =>
       settingsRegistry[id]!(widget.settings, widget.onSettingsChanged);
 
-  bool _isOn(String switchId) => switch (switchId) {
-        'sortingEnabled' => widget.settings.sortingEnabled,
-        'selectionEnabled' => widget.settings.selectionEnabled,
-        'dragSelectionEnabled' => widget.settings.dragSelectionEnabled,
-        'editingEnabled' => widget.settings.editingEnabled,
-        'columnReorderEnabled' => widget.settings.columnReorderEnabled,
-        'resizableEnabled' => widget.settings.resizableEnabled,
-        'tooltipEnabled' => widget.settings.tooltipEnabled,
-        'rowCardTooltip' => widget.settings.rowCardTooltip,
-        'mergedRowsEnabled' => widget.settings.mergedRowsEnabled,
-        'dynamicRowHeight' => widget.settings.dynamicRowHeight,
-        'dimInactiveRows' => widget.settings.dimInactiveRows,
-        'showAlternateRows' => widget.settings.showAlternateRows,
-        'showDividers' => widget.settings.showDividers,
-        'headerTopBorderShow' => widget.settings.headerTopBorderShow,
-        'headerBottomBorderShow' => widget.settings.headerBottomBorderShow,
-        'headerVerticalDividerShow' =>
-          widget.settings.headerVerticalDividerShow,
-        _ => true,
-      };
+  /// Whether a feature's switch is on.
+  ///
+  /// This used to be a hand-written switch statement with `_ => true` at the
+  /// bottom, so a feature whose switch nobody taught it to read was drawn as
+  /// permanently on. `featureSwitches` is held to the description by a test.
+  bool _isOn(String switchId) =>
+      featureSwitches[switchId]!.read(widget.settings);
 
   Widget _rowCountBadge(PlaygroundSettings s) {
     return Row(

--- a/example/test/preset_bar_test.dart
+++ b/example/test/preset_bar_test.dart
@@ -1,0 +1,60 @@
+import 'package:example/pages/playground/models/settings_presets.dart';
+import 'package:example/pages/playground/playground_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_table_plus/flutter_table_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// The playground opens bare, because an addition needs a zero to be measured
+// against. A preset is not a label on the settings — pressing one changes the
+// table, and that is what these check.
+//
+// The checkbox column is the visible proof: it exists only while selection is
+// on, which `Bare` turns off and `Everything` turns back on.
+
+Future<void> _pumpPlayground(WidgetTester tester) async {
+  tester.view.physicalSize = const Size(1800, 1000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(const MaterialApp(home: PlaygroundPage()));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('the playground opens bare, and says what to look for',
+      (tester) async {
+    await _pumpPlayground(tester);
+
+    for (final preset in presets) {
+      expect(find.text(preset.title), findsOneWidget, reason: preset.id);
+    }
+    expect(find.text(presetById('bare').lookFor), findsOneWidget);
+
+    expect(find.byType(FlutterCheckbox), findsNothing,
+        reason: 'selection is off, so there is no checkbox column');
+  });
+
+  testWidgets('pressing a preset changes the table, not just the label',
+      (tester) async {
+    await _pumpPlayground(tester);
+
+    await tester.tap(find.text('Everything'));
+    await tester.pumpAndSettle();
+
+    expect(find.text(presetById('everything').lookFor), findsOneWidget);
+    expect(find.byType(FlutterCheckbox), findsWidgets,
+        reason: 'selection is on now');
+  });
+
+  testWidgets('changing a setting by hand releases the preset', (tester) async {
+    await _pumpPlayground(tester);
+    expect(find.text(presetById('bare').lookFor), findsOneWidget);
+
+    // Any control will do; the row-count quick buttons are always visible.
+    await tester.tap(find.text('1.0K'));
+    await tester.pumpAndSettle();
+
+    expect(find.text(presetById('bare').lookFor), findsNothing,
+        reason: 'the settings no longer match any preset');
+  });
+}

--- a/example/test/settings_presets_test.dart
+++ b/example/test/settings_presets_test.dart
@@ -1,0 +1,98 @@
+import 'package:example/pages/playground/models/feature_switches.dart';
+import 'package:example/pages/playground/models/playground_settings.dart';
+import 'package:example/pages/playground/models/settings_presets.dart';
+import 'package:example/pages/playground/models/settings_spec.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// A preset is a set of feature switches applied to the settings. It needed none
+// of the description, the registry or the rendering rewrite — `copyWith` was
+// always enough — which is why it now goes first.
+//
+// Reading and writing a switch by name is the one thing Dart cannot do for us.
+// `featureSwitches` holds that knowledge, and the first test holds it to the
+// description: a feature whose switch nobody taught the map to read would be
+// silently reported as on.
+
+Set<String> _specSwitchIds() => {
+      for (final g in settingsSpec)
+        for (final f in g.features)
+          if (f.switchId != null) f.switchId!,
+    };
+
+void main() {
+  test('every feature switch the description declares can be read and written',
+      () {
+    final declared = _specSwitchIds();
+    expect(declared, hasLength(16));
+    expect(featureSwitches.keys.toSet(), declared,
+        reason: 'a switch nobody can read is a feature that is always on');
+  });
+
+  group('applyPreset', () {
+    test('bare turns every feature off', () {
+      final bare = applyPreset(const PlaygroundSettings(), presets.first);
+      expect(presets.first.id, 'bare');
+
+      for (final entry in featureSwitches.entries) {
+        expect(entry.value.read(bare), isFalse, reason: entry.key);
+      }
+    });
+
+    test('bare leaves the row count alone', () {
+      const base = PlaygroundSettings(rowCount: 100);
+      expect(applyPreset(base, presetById('bare')).rowCount, 100,
+          reason: 'a table with no scroll cannot show drag selection');
+    });
+
+    test('everything turns every feature on', () {
+      final all =
+          applyPreset(const PlaygroundSettings(), presetById('everything'));
+      for (final entry in featureSwitches.entries) {
+        expect(entry.value.read(all), isTrue, reason: entry.key);
+      }
+    });
+
+    test('a preset switches off what it does not name', () {
+      const on = PlaygroundSettings(mergedRowsEnabled: true);
+      final after = applyPreset(on, presetById('selectionAndEditing'));
+      expect(after.mergedRowsEnabled, isFalse);
+      expect(after.selectionEnabled, isTrue);
+      expect(after.editingEnabled, isTrue);
+    });
+  });
+
+  group('a preset named for an interaction must produce it', () {
+    test('selection + editing turns on both, and nothing else', () {
+      final s = applyPreset(
+          const PlaygroundSettings(), presetById('selectionAndEditing'));
+      expect(s.selectionEnabled, isTrue);
+      expect(s.editingEnabled, isTrue);
+      expect(s.dragSelectionEnabled, isFalse);
+    });
+
+    test('drag over merged rows turns on all three it needs', () {
+      // Dragging selects nothing without selection, and a merged group cannot
+      // be crossed if there are none. A preset that named the interaction and
+      // left one of these off would demonstrate nothing.
+      final s = applyPreset(
+          const PlaygroundSettings(), presetById('dragOverMergedRows'));
+      expect(s.dragSelectionEnabled, isTrue);
+      expect(s.selectionEnabled, isTrue);
+      expect(s.mergedRowsEnabled, isTrue);
+    });
+  });
+
+  test('every preset says what to look for', () {
+    for (final p in presets) {
+      expect(p.title.trim(), isNotEmpty, reason: p.id);
+      expect(p.lookFor.trim(), isNotEmpty, reason: p.id);
+    }
+  });
+
+  test('every preset names features the description knows', () {
+    final declared = _specSwitchIds();
+    for (final p in presets) {
+      expect(p.featuresOn.difference(declared), isEmpty, reason: p.id);
+    }
+  });
+}


### PR DESCRIPTION
Closes #83

The playground opened with sorting, selection and editing already on, and nothing said what any of them did. It opens **Bare** now: every feature off, the row count untouched — the row count is not what makes a table bare, and a table with no scroll cannot show drag selection or auto-scroll.

Four presets sit above the table. Two are structural. The other two are named for the **interaction** they demonstrate, not the features they enable: `Selection` and `Editing` are switches the panel already has, and a preset named after one says nothing a switch did not, while `Selection + Editing` answers whether a tap edits the cell or selects the row.

A preset that names an interaction has to produce it. `Drag select over merged rows` turns on all three features that interaction needs, and a test fails if one is dropped — dragging selects nothing without selection, and a merged group cannot be crossed if there are none.

Each preset carries the line that earns its name: not which features it turned on, but what to watch now that they are.

A preset is a path to a state, not the state. Touching any setting by hand releases it, and a test holds that line.

## This should have been first

This work was sliced with presets last, behind a control id, a description of the settings, a rendering rewrite and dependency gating. Four pull requests merged and the screen barely changed, while the complaint that started it — too many toggles, no hierarchy, no sense of what relates to what — went untouched.

A preset needed none of it. `copyWith` was always enough. The description contributes exactly one thing here: the invariant that sixteen feature switches are declared.

## A silent default is gone

Reading a settings field by name is the one thing Dart cannot do for us, and the panel had been guessing: `_isOn` was a hand-written switch statement ending in `_ => true`. A feature whose switch nobody taught it to read would have drawn as permanently on, in silence, and no test would have said so.

That knowledge is a map now, held to the description by a test: a declared switch missing from it turns the suite red. The panel reads through it, and `applyPreset` writes through it, so reading and writing cannot drift apart.

## Verification

`cd example && flutter test` passes (51 tests: 39 existing, 12 new), the package's 382 are untouched and green, `flutter analyze` is clean in both, `dart format` leaves both unchanged, nothing overflows under the widget-test font.

Every new test was checked to fail without its production change, each for its own reason: opening on `Everything` fails the bare test, dropping the preset release fails only the release test, removing a switch from the map fails only the invariant. The preset tests assert the **table** changes — the checkbox column exists only while selection is on — not that a label changed.

Driven and confirmed on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)