### PR TITLE
A list of features, not a wall of toggles

### DIFF
--- a/example/lib/pages/playground/playground_page.dart
+++ b/example/lib/pages/playground/playground_page.dart
@@ -11,6 +11,7 @@ import 'models/settings_presets.dart';
 import 'playground_columns.dart';
 import 'playground_format.dart';
 import 'utils/random_data_generator.dart';
+import 'widgets/feature_list_pane.dart';
 import 'widgets/performance_monitor.dart';
 import 'widgets/preset_bar.dart';
 import 'widgets/settings_panel.dart';
@@ -40,6 +41,10 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
   /// The preset whose state the settings still match, or null once the reader
   /// has changed something by hand.
   String? _activePresetId = 'bare';
+
+  /// The feature whose detail is shown. The list selects; nothing reads this
+  /// yet. #85 gives it a pane to open into.
+  String? _selectedFeatureId;
 
   // Data
   List<Employee> _data = [];
@@ -620,6 +625,14 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
           Expanded(
             child: Row(
               children: [
+                FeatureListPane(
+                  settings: _settings,
+                  selectedFeatureId: _selectedFeatureId,
+                  onSettingsChanged: _handleSettingsChanged,
+                  onFeatureSelected: (id) =>
+                      setState(() => _selectedFeatureId = id),
+                ),
+
                 // Left: Settings Panel
                 SettingsPanel(
                   settings: _settings,

--- a/example/lib/pages/playground/widgets/feature_list_pane.dart
+++ b/example/lib/pages/playground/widgets/feature_list_pane.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+
+import '../models/feature_switches.dart';
+import '../models/playground_settings.dart';
+import '../models/settings_spec.dart';
+
+/// The twenty features, in a column of their own.
+///
+/// Sixty-eight controls used to stand here. Each row now answers two questions —
+/// is this on, and how much is inside it — and defers the rest to whatever pane
+/// shows the feature you pick.
+///
+/// Four features own no switch. Rows, Zoom, Rows and text and Row ink are
+/// headings over settings that are always live, and a dot beside them would
+/// offer to turn off something that cannot be turned off.
+class FeatureListPane extends StatelessWidget {
+  const FeatureListPane({
+    super.key,
+    required this.settings,
+    required this.selectedFeatureId,
+    required this.onSettingsChanged,
+    required this.onFeatureSelected,
+  });
+
+  final PlaygroundSettings settings;
+  final String? selectedFeatureId;
+  final ValueChanged<PlaygroundSettings> onSettingsChanged;
+  final ValueChanged<String> onFeatureSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 180,
+      height: double.infinity,
+      decoration: BoxDecoration(
+        color: Colors.grey.shade50,
+        border: Border(right: BorderSide(color: Colors.grey.shade300)),
+      ),
+      child: ListView(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        children: [
+          for (final group in settingsSpec) ...[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+              child: Text(
+                group.title.toUpperCase(),
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0.8,
+                  color: Colors.grey.shade600,
+                ),
+              ),
+            ),
+            for (final feature in group.features) _entry(feature),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _entry(SettingFeature feature) {
+    final switchId = feature.switchId;
+    final on = switchId != null && featureSwitches[switchId]!.read(settings);
+
+    return KeyedSubtree(
+      key: ValueKey('feature-${feature.id}'),
+      child: ListTile(
+        dense: true,
+        selected: feature.id == selectedFeatureId,
+        contentPadding: const EdgeInsets.only(left: 4, right: 12),
+        // The name selects. Selecting is not enabling — a reader must be able to
+        // look at a feature that is off, and see what it would offer.
+        onTap: () => onFeatureSelected(feature.id),
+        leading: switchId == null
+            ? const SizedBox(width: 40)
+            : _Dot(
+                key: ValueKey('feature-dot-${feature.id}'),
+                on: on,
+                onTap: () => onSettingsChanged(
+                  featureSwitches[switchId]!.write(settings, !on),
+                ),
+              ),
+        title: Text(
+          feature.title,
+          // The list is 180 wide and the widget-test font draws every glyph as a
+          // square of the font size, so a name that fits on screen overflows
+          // there. Let it ellipsize.
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(fontSize: 13),
+        ),
+        trailing: feature.options.isEmpty
+            ? null
+            : Text(
+                '${feature.options.length}',
+                style: TextStyle(fontSize: 11, color: Colors.grey.shade500),
+              ),
+      ),
+    );
+  }
+}
+
+class _Dot extends StatelessWidget {
+  const _Dot({super.key, required this.on, required this.onTap});
+
+  final bool on;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 40,
+      child: InkResponse(
+        onTap: onTap,
+        radius: 18,
+        child: Icon(
+          on ? Icons.circle : Icons.circle_outlined,
+          size: 14,
+          color: on ? Colors.blue.shade600 : Colors.grey.shade400,
+        ),
+      ),
+    );
+  }
+}

--- a/example/test/feature_list_test.dart
+++ b/example/test/feature_list_test.dart
@@ -1,0 +1,165 @@
+import 'package:example/pages/playground/models/feature_switches.dart';
+import 'package:example/pages/playground/models/playground_settings.dart';
+import 'package:example/pages/playground/models/settings_presets.dart';
+import 'package:example/pages/playground/models/settings_spec.dart';
+import 'package:example/pages/playground/playground_page.dart';
+import 'package:example/pages/playground/widgets/feature_list_pane.dart';
+import 'package:flutter_table_plus/flutter_table_plus.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Sixty-eight controls stood in a column. The list shows twenty names instead,
+// and answers two questions per row: is this on, and how much is inside it.
+//
+// Four of the twenty own no switch — Rows, Zoom, Rows and text, Row ink are
+// headings over settings that are always live. A dot beside them would offer to
+// turn off something that cannot be turned off.
+
+/// The list is 1,088px tall with every entry built; a 600px test surface would
+/// leave the last group unmounted and every assertion about it vacuously true.
+void _tallView(WidgetTester tester) {
+  tester.view.physicalSize = const Size(400, 1400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+Widget _pane({
+  PlaygroundSettings? settings,
+  String? selected,
+  ValueChanged<PlaygroundSettings>? onSettingsChanged,
+  ValueChanged<String>? onFeatureSelected,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        width: 180,
+        child: FeatureListPane(
+          settings: settings ??
+              applyPreset(const PlaygroundSettings(), presetById('bare')),
+          selectedFeatureId: selected,
+          onSettingsChanged: onSettingsChanged ?? (_) {},
+          onFeatureSelected: onFeatureSelected ?? (_) {},
+        ),
+      ),
+    ),
+  );
+}
+
+Iterable<SettingFeature> get _features =>
+    settingsSpec.expand((g) => g.features);
+
+void main() {
+  testWidgets('every feature appears, under its group', (tester) async {
+    _tallView(tester);
+    await tester.pumpWidget(_pane());
+
+    for (final group in settingsSpec) {
+      expect(find.text(group.title.toUpperCase()), findsOneWidget,
+          reason: group.id);
+    }
+    for (final feature in _features) {
+      expect(find.text(feature.title), findsOneWidget, reason: feature.id);
+    }
+  });
+
+  testWidgets('an entry says how many options it holds', (tester) async {
+    _tallView(tester);
+    await tester.pumpWidget(_pane());
+
+    // Selection owns five; drag selection owns none and says nothing.
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('feature-selection')),
+        matching: find.text('5'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('feature-dragSelection')),
+        matching: find.byType(Text),
+      ),
+      findsOneWidget,
+      reason: 'a feature with no options shows only its name',
+    );
+  });
+
+  testWidgets('the dot turns a feature on', (tester) async {
+    PlaygroundSettings? changed;
+    _tallView(tester);
+    await tester.pumpWidget(_pane(onSettingsChanged: (s) => changed = s));
+
+    expect(
+        featureSwitches['sortingEnabled']!
+            .read(applyPreset(const PlaygroundSettings(), presetById('bare'))),
+        isFalse);
+
+    await tester.tap(find.byKey(const ValueKey('feature-dot-sorting')));
+    await tester.pumpAndSettle();
+
+    expect(changed, isNotNull);
+    expect(featureSwitches['sortingEnabled']!.read(changed!), isTrue);
+  });
+
+  testWidgets('the name selects, and does not toggle', (tester) async {
+    String? selected;
+    PlaygroundSettings? changed;
+    _tallView(tester);
+    await tester.pumpWidget(_pane(
+      onFeatureSelected: (id) => selected = id,
+      onSettingsChanged: (s) => changed = s,
+    ));
+
+    await tester.tap(find.text('Sorting'));
+    await tester.pumpAndSettle();
+
+    expect(selected, 'sorting');
+    expect(changed, isNull, reason: 'selecting is not enabling');
+  });
+
+  testWidgets('the selected entry is visibly selected', (tester) async {
+    _tallView(tester);
+    await tester.pumpWidget(_pane(selected: 'resizing'));
+
+    final tile = tester.widget<ListTile>(
+      find.descendant(
+        of: find.byKey(const ValueKey('feature-resizing')),
+        matching: find.byType(ListTile),
+      ),
+    );
+    expect(tile.selected, isTrue);
+  });
+
+  testWidgets('a feature with no switch has no dot', (tester) async {
+    _tallView(tester);
+    await tester.pumpWidget(_pane());
+
+    for (final feature in _features) {
+      final dot = find.byKey(ValueKey('feature-dot-${feature.id}'));
+      if (feature.switchId == null) {
+        expect(dot, findsNothing, reason: '${feature.id} cannot be turned off');
+      } else {
+        expect(dot, findsOneWidget, reason: feature.id);
+      }
+    }
+  });
+
+  testWidgets('the dot changes the table, not just the callback',
+      (tester) async {
+    tester.view.physicalSize = const Size(1800, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(const MaterialApp(home: PlaygroundPage()));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FlutterCheckbox), findsNothing,
+        reason: 'the playground opens bare');
+
+    await tester.tap(find.byKey(const ValueKey('feature-dot-selection')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FlutterCheckbox), findsWidgets,
+        reason: 'the checkbox column exists only while selection is on');
+  });
+}


### PR DESCRIPTION
Closes #84

Sixty-eight controls stood in a column. Twenty names stand there now, grouped under the four headings the description already knew, and each row answers two questions: is this on, and how much is inside it.

**The dot toggles. The name selects.** Selecting is not enabling — a reader has to be able to look at a feature that is off and see what it would offer. Nothing reads that selection yet; #85 gives it a pane to open into.

Four of the twenty own no switch. `Rows`, `Zoom`, `Rows and text` and `Row ink` are headings over settings that are always live, and a dot beside them would offer to turn off something that cannot be turned off. A test walks the description and insists on exactly that.

The old panel stays. Two panels side by side is not the destination; it is how the destination is reached without a step where nothing works.

## Three tests were passing on a list that was never there

Built out, the list is 1,088 pixels tall. The default test surface is 600. The last group was never mounted, and `find.byKey` only sees mounted elements — so `findsNothing` was true of everything below the fold, and one test walked all twenty features, checking a dot where there is a switch and none where there is not, while seeing only the half that existed.

One assertion failed, on a heading it could not find, and that is the only reason any of this came out. The tests give the list room now, and the one that had been vacuously true fails when a dot is drawn beside a feature with no switch.

`findsNothing` on an unmounted widget is not a check. It is the widget-test form of reading an empty result as an answer.

## Verification

`cd example && flutter test` passes (58 tests: 51 existing, 7 new), the package's 382 are untouched and green, `flutter analyze` is clean in both, `dart format` leaves both unchanged, nothing overflows under the widget-test font — the list is 180 wide and its names ellipsize.

Every new test was checked to fail without its production change. Drawing a dot beside a container fails two of them; making the name toggle as well as select fails only the one that says selecting is not enabling. The last test asserts the **table** changes when the dot is tapped — the checkbox column exists only while selection is on — not that a callback fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)