### PR TITLE
The detail pane says which features this one changes

### DIFF
--- a/example/lib/pages/playground/models/settings_spec.dart
+++ b/example/lib/pages/playground/models/settings_spec.dart
@@ -121,11 +121,13 @@ const settingsSpec = <SettingGroup>[
           ),
           Interaction(
             otherFeatureId: 'mergedRows',
-            effect: 'A merged group is selected as one unit, not as the rows '
-                'it stands for.',
-            evidence: 'row_lookup.dart derives idToGroup from mergedGroups; '
-                'CLAUDE.md, "Merged row groups are treated as single units for '
-                'selection and editing operations"',
+            effect: 'Selecting a merged row reports the group id once, not the '
+                'ids of the rows it stands for.',
+            // `row_lookup.dart` only builds an id→group map; a lookup table
+            // settles nothing. What settles it is which id reaches the
+            // callback, and that is decided here.
+            evidence: 'table_plus_merged_row.dart calls '
+                'onRowSelectionChanged(mergeGroup.groupId)',
           ),
         ],
       ),
@@ -136,13 +138,19 @@ const settingsSpec = <SettingGroup>[
         interactions: [
           Interaction(
             otherFeatureId: 'selection',
-            effect: 'Dragging selects nothing while selection is off. The '
-                'table requires both.',
+            effect: 'Dragging selects nothing while selection is off, and '
+                'nothing in single-selection mode either. The table wires the '
+                'drag handlers only when both hold.',
             // Cite the library, not the panel. The panel's shape is ours to
             // change, and citing it went stale the moment the sections that
             // guarded this control were deleted.
+            //
+            // Quoted in full: an abridged expression is worse than none. This
+            // used to omit the selectionMode term, which read as a promise that
+            // dragging works in single-selection mode.
             evidence: 'flutter_table_plus.dart: _isDragSelectionEnabled is '
                 'enableDragSelection && isSelectable && '
+                'selectionMode == SelectionMode.multiple && '
                 'onDragSelectionUpdate != null',
           ),
           Interaction(
@@ -151,8 +159,8 @@ const settingsSpec = <SettingGroup>[
                 'ids of the rows inside it.',
             evidence:
                 'test/drag_selection_test.dart, "dragging across a merged '
-                'group adds the group ID, not individual rows"; RowGeometry '
-                'snapshots "row id or merged group id"',
+                'group adds the group ID, not individual rows"; table_body.dart '
+                'snapshots each render row as a "row id or merged group id"',
           ),
         ],
       ),
@@ -219,11 +227,15 @@ const settingsSpec = <SettingGroup>[
         interactions: [
           Interaction(
             otherFeatureId: 'rowCard',
-            effect: 'Turning tooltips off silences the row card too. And with '
+            effect: 'Turning tooltips off silences the row card too — the '
+                'playground gives the card its enabled flag. And with '
                 'TooltipBehavior.always every ellipsized column already has a '
                 'tooltip, which leaves the card nowhere to appear.',
-            evidence: 'test/row_tooltip_test.dart, "TooltipBehavior.always '
-                'leaves no room for the card"; CHANGELOG 2.14.0',
+            // Two claims, so two citations. The test only backs the second.
+            // The first is a control-flow fact one line above the wrapper.
+            evidence: 'table_body.dart returns the row unwrapped when '
+                '!rowTooltipTheme.enabled; test/row_tooltip_test.dart, '
+                '"TooltipBehavior.always leaves no room for the card"',
           ),
         ],
       ),
@@ -235,11 +247,14 @@ const settingsSpec = <SettingGroup>[
         interactions: [
           Interaction(
             otherFeatureId: 'mergedRows',
-            effect: 'A merged row carries no card. It stands for several data '
-                'rows, so there is no single one to build the card from.',
+            // The direction matters. The builder is not called and its result
+            // discarded; the table never calls it, because a merged row stands
+            // for several data rows and there is no single one to hand over.
+            effect: 'The card is never built for a merged row. It stands for '
+                'several data rows, so there is no single one to build from.',
             evidence: 'table_body.dart returns the row unwrapped when '
-                '_getMergedGroupForRow is non-null; test/row_tooltip_test.dart, '
-                '"a merged row carries no card"',
+                '_getMergedGroupForRow is non-null, before calling the builder; '
+                'test/row_tooltip_test.dart, "a merged row carries no card"',
           ),
         ],
       ),

--- a/example/lib/pages/playground/widgets/feature_detail_pane.dart
+++ b/example/lib/pages/playground/widgets/feature_detail_pane.dart
@@ -43,11 +43,62 @@ class FeatureDetailPane extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
             style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
           ),
+          if (feature.interactions.isNotEmpty) _affects(),
           const SizedBox(height: 12),
           if (feature.switchId != null) _draw(feature.switchId!),
           if (feature.id == 'data') _rowCountBadge(),
           if (feature.options.isNotEmpty) _options(),
           if (feature.id == 'data') ..._dataExtras(),
+        ],
+      ),
+    );
+  }
+
+  /// What this feature does to the others.
+  ///
+  /// A reader flips a switch and something unrelated behaves differently, with
+  /// nothing on screen to say why — and an agent reading the code concludes the
+  /// features are independent. These are the couplings the description records,
+  /// each carrying a citation that a human has read.
+  ///
+  /// Stated in the direction it happens. "A merged row carries no card" and
+  /// "the card is never built for a merged row" are different claims; only one
+  /// of them is what `table_body.dart` does.
+  Widget _affects() {
+    return Container(
+      margin: const EdgeInsets.only(top: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.amber.shade50,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: Colors.amber.shade200),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Affects',
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.8,
+              color: Colors.amber.shade900,
+            ),
+          ),
+          for (final i in feature.interactions) ...[
+            const SizedBox(height: 8),
+            Text(
+              featureById(i.otherFeatureId).title,
+              style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 2),
+            // The pane is 380 wide and the widget-test font draws every glyph
+            // as a square of the font size. This wraps; it must never be a Row.
+            Text(
+              i.effect,
+              style: TextStyle(fontSize: 12, color: Colors.grey.shade800),
+            ),
+          ],
         ],
       ),
     );

--- a/example/test/feature_detail_test.dart
+++ b/example/test/feature_detail_test.dart
@@ -165,6 +165,33 @@ void main() {
     expect(changed, isNotNull);
   });
 
+  testWidgets('a feature says which others it changes, and what happens',
+      (tester) async {
+    _tallView(tester);
+
+    // Read from the description, not restated here: a wording this test copied
+    // would agree with itself forever.
+    for (final feature in _features.where((f) => f.interactions.isNotEmpty)) {
+      await tester.pumpWidget(_pane(feature));
+
+      for (final i in feature.interactions) {
+        expect(find.text(featureById(i.otherFeatureId).title), findsOneWidget,
+            reason: '${feature.id} → ${i.otherFeatureId}');
+        expect(find.text(i.effect), findsOneWidget, reason: feature.id);
+      }
+    }
+  });
+
+  testWidgets('a feature with no recorded interaction shows none',
+      (tester) async {
+    _tallView(tester);
+
+    final quiet = _features.firstWhere((f) => f.interactions.isEmpty);
+    await tester.pumpWidget(_pane(quiet));
+
+    expect(find.text('Affects'), findsNothing, reason: quiet.id);
+  });
+
   testWidgets('picking a feature opens it, and its switch changes the table',
       (tester) async {
     tester.view.physicalSize = const Size(1800, 1000);


### PR DESCRIPTION
Closes #86

Turning on drag selection changes what a merged row means. `TooltipBehavior.always` leaves the row card nowhere to appear. All of it was written down, none of it was on screen where the switches are — so a reader flips one and something unrelated behaves differently, and an agent reading the code concludes the features are independent.

The seven interactions the description records now sit under the feature's name, each saying what happens and in which direction. A feature with none shows none. The test reads the wording out of the description rather than restating it, because a test that copies the prose agrees with itself forever.

## Three of the seven citations were false

The claims were all true. Three of the citations were not, and no test could have caught that. A conclusion that is wrong gets caught by a test. A **reason** that is wrong gets believed by the next person.

**`dragSelection → selection`** cited `_isDragSelectionEnabled` as three terms. It has four, and the missing one is `selectionMode == SelectionMode.multiple`. Abridged, it read as a promise that dragging works in single-selection mode. The effect said the table "requires both"; it requires three things. Both are corrected and the expression is now quoted whole. This is the *second* bad citation this one interaction has carried — #82 was the first, when it cited a panel layout that had already been deleted.

**`selection → mergedRows`** cited `row_lookup.dart` building an id→group map. A lookup table settles nothing about what gets selected. What settles it is which id reaches the callback: `table_plus_merged_row.dart` calls `onRowSelectionChanged(mergeGroup.groupId)`.

**`tooltips → rowCard`** made two claims and cited one. The row-tooltip test backs "`always` leaves no room for the card" and is silent about turning tooltips off. That half is a control-flow fact: `table_body.dart` returns the row unwrapped when `!rowTooltipTheme.enabled`, and the playground wires that flag to the tooltip switch.

Two more were re-aimed rather than fixed. `dragSelection → mergedRows` attributed a doc comment to `RowGeometry` when it lives in `table_body.dart`. And `rowCard → mergedRows` said "a merged row carries no card" — the observation, not what the code does: the table returns the row unwrapped *before calling the builder*. Direction stated.

The remaining two were read and confirmed. The CHANGELOG says in as many words that the cell's own `GestureDetector` wins the gesture arena against the row-level tap.

## What the spec test can and cannot do

`settings_spec_test` insists every interaction names a real feature and carries a citation. It cannot read the code the citation points at. Its own doc comment says so, and #86 handed that job to a human rather than pretend otherwise. Checking that seven citations *exist* — which `grep` does in a second — would have missed all three.

## Verification

`cd example`: `flutter analyze` clean, 59 tests green, `dart format` unchanged. Package: 382 green, analyze clean, format unchanged. Nothing overflows — the effect text wraps in a 380px pane and is never inside a `Row`.

Both new tests were checked to fail without their production change: removing the block fails the one that reads the seven, and drawing it unconditionally fails the one that says a quiet feature stays quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)