### PR TITLE
Search the feature list, and say where a setting lives

### DIFF
--- a/example/lib/pages/playground/widgets/feature_list_pane.dart
+++ b/example/lib/pages/playground/widgets/feature_list_pane.dart
@@ -3,17 +3,24 @@ import 'package:flutter/material.dart';
 import '../models/feature_switches.dart';
 import '../models/playground_settings.dart';
 import '../models/settings_spec.dart';
+import 'feature_search.dart';
 
 /// The twenty features, in a column of their own.
 ///
 /// Sixty-eight controls used to stand here. Each row now answers two questions —
-/// is this on, and how much is inside it — and defers the rest to whatever pane
+/// is this on, and how much is inside it — and defers the rest to the pane that
 /// shows the feature you pick.
 ///
 /// Four features own no switch. Rows, Zoom, Rows and text and Row ink are
 /// headings over settings that are always live, and a dot beside them would
 /// offer to turn off something that cannot be turned off.
-class FeatureListPane extends StatelessWidget {
+///
+/// A search narrows this list rather than a column of controls, because the
+/// setting someone is hunting almost always belongs to a feature they have not
+/// opened. Under each surviving name it says which setting matched, so
+/// `Handle Indent` can be found to live under Column resizing without opening
+/// anything.
+class FeatureListPane extends StatefulWidget {
   const FeatureListPane({
     super.key,
     required this.settings,
@@ -28,74 +35,166 @@ class FeatureListPane extends StatelessWidget {
   final ValueChanged<String> onFeatureSelected;
 
   @override
+  State<FeatureListPane> createState() => _FeatureListPaneState();
+}
+
+class _FeatureListPaneState extends State<FeatureListPane> {
+  final _search = TextEditingController();
+
+  @override
+  void dispose() {
+    _search.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final query = _search.text;
+    final matches = searchFeatures(query, widget.settings);
+    final searching = query.trim().isNotEmpty;
+
     return Container(
-      width: 180,
+      width: 220,
       height: double.infinity,
       decoration: BoxDecoration(
         color: Colors.grey.shade50,
         border: Border(right: BorderSide(color: Colors.grey.shade300)),
       ),
-      child: ListView(
-        padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Column(
         children: [
-          for (final group in settingsSpec) ...[
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
-              child: Text(
-                group.title.toUpperCase(),
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  fontSize: 11,
-                  fontWeight: FontWeight.w700,
-                  letterSpacing: 0.8,
-                  color: Colors.grey.shade600,
-                ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(8, 12, 8, 4),
+            child: TextField(
+              controller: _search,
+              onChanged: (_) => setState(() {}),
+              style: const TextStyle(fontSize: 13),
+              decoration: InputDecoration(
+                isDense: true,
+                hintText: 'Search',
+                prefixIcon: const Icon(Icons.search, size: 18),
+                suffixIcon: searching
+                    ? IconButton(
+                        icon: const Icon(Icons.clear, size: 16),
+                        onPressed: () => setState(_search.clear),
+                      )
+                    : null,
+                border: const OutlineInputBorder(),
               ),
             ),
-            for (final feature in group.features) _entry(feature),
-          ],
+          ),
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.only(bottom: 8),
+              children: [
+                // While a search runs the groups say nothing: the list is no
+                // longer the description's shape, it is the query's.
+                if (searching)
+                  for (final match in matches) _entry(match)
+                else
+                  for (final group in settingsSpec) ...[
+                    _groupHeading(group.title),
+                    for (final feature in group.features)
+                      _entry(matches
+                          .firstWhere((m) => m.feature.id == feature.id)),
+                  ],
+              ],
+            ),
+          ),
         ],
       ),
     );
   }
 
-  Widget _entry(SettingFeature feature) {
+  Widget _groupHeading(String title) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+      child: Text(
+        title.toUpperCase(),
+        overflow: TextOverflow.ellipsis,
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.8,
+          color: Colors.grey.shade600,
+        ),
+      ),
+    );
+  }
+
+  Widget _entry(FeatureMatch match) {
+    final feature = match.feature;
     final switchId = feature.switchId;
-    final on = switchId != null && featureSwitches[switchId]!.read(settings);
+    final on =
+        switchId != null && featureSwitches[switchId]!.read(widget.settings);
 
     return KeyedSubtree(
       key: ValueKey('feature-${feature.id}'),
-      child: ListTile(
-        dense: true,
-        selected: feature.id == selectedFeatureId,
-        contentPadding: const EdgeInsets.only(left: 4, right: 12),
-        // The name selects. Selecting is not enabling — a reader must be able to
-        // look at a feature that is off, and see what it would offer.
-        onTap: () => onFeatureSelected(feature.id),
-        leading: switchId == null
-            ? const SizedBox(width: 40)
-            : _Dot(
-                key: ValueKey('feature-dot-${feature.id}'),
-                on: on,
-                onTap: () => onSettingsChanged(
-                  featureSwitches[switchId]!.write(settings, !on),
-                ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          ListTile(
+            dense: true,
+            selected: feature.id == widget.selectedFeatureId,
+            contentPadding: const EdgeInsets.only(left: 4, right: 12),
+            // The name selects. Selecting is not enabling — a reader must be
+            // able to look at a feature that is off, and see what it would
+            // offer.
+            onTap: () => widget.onFeatureSelected(feature.id),
+            leading: switchId == null
+                ? const SizedBox(width: 40)
+                : _Dot(
+                    key: ValueKey('feature-dot-${feature.id}'),
+                    on: on,
+                    onTap: () => widget.onSettingsChanged(
+                      featureSwitches[switchId]!.write(widget.settings, !on),
+                    ),
+                  ),
+            title: Text(
+              feature.title,
+              // The list is narrow and the widget-test font draws every glyph
+              // as a square of the font size, so a name that fits on screen
+              // overflows there. Let it ellipsize.
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(fontSize: 13),
+            ),
+            trailing: feature.options.isEmpty
+                ? null
+                : Text(
+                    '${feature.options.length}',
+                    style: TextStyle(fontSize: 11, color: Colors.grey.shade500),
+                  ),
+          ),
+          if (match.matchedLabels.isNotEmpty) _matched(match),
+        ],
+      ),
+    );
+  }
+
+  /// The settings that matched, under the feature holding them.
+  ///
+  /// A match inside a feature that is off is still a match. Answering with
+  /// silence would leave the reader unable to tell whether the setting does not
+  /// exist or merely cannot be used, so it says which switch to throw.
+  Widget _matched(FeatureMatch match) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(44, 0, 12, 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          for (final label in match.matchedLabels)
+            Text(
+              label,
+              style: TextStyle(fontSize: 11, color: Colors.blue.shade700),
+            ),
+          if (!match.isOn)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                'Turn on ${match.feature.title} to use it',
+                style: TextStyle(fontSize: 10, color: Colors.orange.shade800),
               ),
-        title: Text(
-          feature.title,
-          // The list is 180 wide and the widget-test font draws every glyph as a
-          // square of the font size, so a name that fits on screen overflows
-          // there. Let it ellipsize.
-          overflow: TextOverflow.ellipsis,
-          style: const TextStyle(fontSize: 13),
-        ),
-        trailing: feature.options.isEmpty
-            ? null
-            : Text(
-                '${feature.options.length}',
-                style: TextStyle(fontSize: 11, color: Colors.grey.shade500),
-              ),
+            ),
+        ],
       ),
     );
   }

--- a/example/lib/pages/playground/widgets/feature_search.dart
+++ b/example/lib/pages/playground/widgets/feature_search.dart
@@ -1,0 +1,70 @@
+import '../models/feature_switches.dart';
+import '../models/playground_settings.dart';
+import '../models/settings_spec.dart';
+import 'settings_controls.dart';
+import 'settings_registry.dart';
+
+/// A feature the search kept, and why it kept it.
+class FeatureMatch {
+  const FeatureMatch({
+    required this.feature,
+    required this.nameMatched,
+    required this.matchedLabels,
+    required this.isOn,
+  });
+
+  final SettingFeature feature;
+
+  /// The feature's own name matched the query.
+  final bool nameMatched;
+
+  /// The labels of its settings that matched, in the order the feature lists
+  /// them. Empty when only the name matched, and always empty for a blank
+  /// query.
+  final List<String> matchedLabels;
+
+  /// Whether the feature is switched on. A feature that is off still matches;
+  /// silence cannot say whether a setting is missing or merely unusable.
+  final bool isOn;
+}
+
+/// The features a search for [query] keeps.
+///
+/// A blank query is not a search: every feature survives it, and nothing is
+/// reported as having matched.
+///
+/// The search reads a control's **label**, which only exists once the control
+/// is built — so the registry is run, with a callback that goes nowhere. It
+/// also reads the feature's **name**, because the names are what is on screen,
+/// and typing what you can see and getting nothing back reads as a broken
+/// search rather than as a narrow contract.
+List<FeatureMatch> searchFeatures(String query, PlaygroundSettings settings) {
+  final searching = query.trim().isNotEmpty;
+
+  final matches = <FeatureMatch>[];
+  for (final feature in settingsSpec.expand((g) => g.features)) {
+    final nameMatched = searching && settingMatches(feature.title, query);
+
+    // Only the options. A feature's switch *is* the feature, and listing "Drag
+    // Selection" underneath "Drag selection" says nothing the row above it did
+    // not.
+    final matchedLabels = <String>[];
+    if (searching) {
+      for (final id in feature.options) {
+        final label = settingsRegistry[id]!(settings, (_) {}).label;
+        if (settingMatches(label, query)) matchedLabels.add(label);
+      }
+    }
+
+    if (searching && !nameMatched && matchedLabels.isEmpty) continue;
+
+    matches.add(FeatureMatch(
+      feature: feature,
+      nameMatched: nameMatched,
+      matchedLabels: matchedLabels,
+      isOn: feature.switchId == null ||
+          featureSwitches[feature.switchId!]!.read(settings),
+    ));
+  }
+  return matches;
+}

--- a/example/test/feature_list_test.dart
+++ b/example/test/feature_list_test.dart
@@ -32,7 +32,7 @@ Widget _pane({
   return MaterialApp(
     home: Scaffold(
       body: SizedBox(
-        width: 180,
+        width: 220,
         child: FeatureListPane(
           settings: settings ??
               applyPreset(const PlaygroundSettings(), presetById('bare')),
@@ -142,6 +142,58 @@ void main() {
         expect(dot, findsOneWidget, reason: feature.id);
       }
     }
+  });
+
+  testWidgets('typing narrows the list, and says what matched', (tester) async {
+    _tallView(tester);
+    await tester.pumpWidget(_pane());
+
+    await tester.enterText(find.byType(TextField), 'anchor');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Tooltips'), findsOneWidget);
+    expect(find.text('Cell Anchor'), findsOneWidget,
+        reason: 'a reader sees where the setting lives before opening it');
+    expect(find.text('Sorting'), findsNothing);
+  });
+
+  testWidgets('a setting is found while its feature is off, and says so',
+      (tester) async {
+    _tallView(tester);
+    await tester.pumpWidget(_pane());
+
+    await tester.enterText(find.byType(TextField), 'row card wait');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Row Card Wait'), findsOneWidget);
+    expect(find.textContaining('Turn on'), findsOneWidget,
+        reason: 'silence cannot say whether a setting is missing or unusable');
+  });
+
+  testWidgets('clearing the search restores the list, and keeps the selection',
+      (tester) async {
+    _tallView(tester);
+    await tester.pumpWidget(_pane(selected: 'sorting'));
+
+    await tester.enterText(find.byType(TextField), 'anchor');
+    await tester.pumpAndSettle();
+    expect(find.text('Sorting'), findsNothing);
+
+    await tester.enterText(find.byType(TextField), '');
+    await tester.pumpAndSettle();
+
+    for (final feature in _features) {
+      expect(find.text(feature.title), findsOneWidget, reason: feature.id);
+    }
+    // A search is a way of getting somewhere. Arriving is not undone by
+    // clearing the query that led there.
+    final tile = tester.widget<ListTile>(
+      find.descendant(
+        of: find.byKey(const ValueKey('feature-sorting')),
+        matching: find.byType(ListTile),
+      ),
+    );
+    expect(tile.selected, isTrue);
   });
 
   testWidgets('the dot changes the table, not just the callback',

--- a/example/test/feature_search_test.dart
+++ b/example/test/feature_search_test.dart
@@ -1,0 +1,56 @@
+import 'package:example/pages/playground/models/playground_settings.dart';
+import 'package:example/pages/playground/widgets/feature_search.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Search used to narrow one scrolling column to the controls whose labels
+// matched. There is no such column now: the control someone is hunting almost
+// always belongs to a feature they have not opened. So the search narrows the
+// *list*, and says which setting matched.
+//
+// It matches a feature's name as well as its settings' labels. A feature's name
+// is on screen, and typing what you can see and getting nothing back reads as a
+// broken search, not as a narrow contract.
+
+const _bare = PlaygroundSettings();
+
+List<String> _ids(String query) =>
+    searchFeatures(query, _bare).map((m) => m.feature.id).toList();
+
+FeatureMatch _match(String query, String featureId) =>
+    searchFeatures(query, _bare).firstWhere((m) => m.feature.id == featureId);
+
+void main() {
+  test('a blank query is not a search', () {
+    final all = searchFeatures('', _bare);
+    expect(all, hasLength(20));
+    expect(all.every((m) => m.matchedLabels.isEmpty), isTrue,
+        reason: 'nothing matched, because nothing was asked');
+  });
+
+  test('a query narrows the list to the features that hold a match', () {
+    // 'Cell Anchor' and 'Header Anchor' are both settings of Tooltips.
+    expect(_ids('anchor'), ['tooltips']);
+    expect(_match('anchor', 'tooltips').matchedLabels,
+        containsAll(['Cell Anchor', 'Header Anchor']));
+  });
+
+  test("a feature's own name matches", () {
+    final m = _match('drag', 'dragSelection');
+    expect(m.nameMatched, isTrue);
+    expect(m.matchedLabels, isEmpty,
+        reason: 'Drag selection owns no options; only its name matched');
+  });
+
+  test('a setting is found while its feature is off', () {
+    expect(_bare.rowCardTooltip, isFalse);
+
+    final m = _match('row card wait', 'rowCard');
+    expect(m.matchedLabels, ['Row Card Wait']);
+    expect(m.isOn, isFalse,
+        reason: 'absent and non-existent are different things');
+  });
+
+  test('a query that matches nothing narrows to nothing', () {
+    expect(_ids('zzz'), isEmpty);
+  });
+}


### PR DESCRIPTION
Closes #87

Search was built when the panel was one scrolling column, and it narrowed that column to the controls whose labels matched. There is no such column. The setting someone is hunting almost always belongs to a feature they have not opened, so the search narrows the **list** and says which setting matched — `Handle Indent` is seen to live under Column resizing without opening anything.

A setting whose feature is off is still found, and the result says which switch to throw. A search that answers with silence cannot tell you whether the setting does not exist or merely cannot be used.

## Decided: the search matches feature names too

The issue said both answers were defensible and an unstated one was not.

Names match. They are on screen — twenty of them, in the pane the search box sits in. Typing what you can see and getting nothing back reads as a broken search, not as a narrow contract.

A feature's **switch** is excluded from the matched settings, though its label is a control label like any other. The switch *is* the feature; printing "Drag Selection" beneath "Drag selection" says nothing the row above it did not. This came out of a red test: `drag` matched the switch label, and the test that expected no matched settings was right while the implementation was noisy.

## Decided: clearing the search keeps the selected feature

A search is a way of getting somewhere. Arriving is not undone by clearing the query that led there. The list restores; the pane stays where the search took you.

The test that pins this is a **meaning guard, not a regression guard** — nothing in the pane touches the selection, so it passes without the decision. It records which behaviour was chosen, in the way `scaledBy leaves an unset tooltip theme unset` does.

## The seam

`searchFeatures` is a pure function over the description and the settings, so the rules — what matches, what is reported, whether a feature is on — are tested without pumping a widget. It has to run the registry to see a label at all, because a label only exists once its control is built; the callback it hands over goes nowhere.

The two search tests that pumped the old panel were already deleted with it in #85. `settings_search_test.dart` survives untouched: it tests `settingMatches`, which still means what it meant.

## Verification

`cd example`: `flutter analyze` clean, 67 tests green (5 new pure, 3 new widget), `dart format` unchanged. Package: 382 green, analyze clean, format unchanged.

The list widened from 180 to 220 to hold the search box and the match lines without the widget-test font bursting it. Each new test was checked to fail without its production change: switching the filter off fails three, and dropping either the matched labels or the "Turn on" line fails the ones that name them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)